### PR TITLE
Enable the IDE cell evaluation with webr-r tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.luarc.json

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ filters:
 
 This is a webr-enabled code cell in a Quarto HTML document.
 
-```{webr}
+```{webr-r}
 fit = lm(mpg ~ am, data = mtcars)
 summary(fit)
 ```
@@ -148,8 +148,8 @@ For additional justificaiton on why the headers are required, please see [webR's
 
 ### Engine Registration
 
-If using the `knitr` engine instead of the `jupyter` engine, there is a known warning
-that will appear in the render processing output of:
+If using the `knitr` engine instead of the `jupyter` engine and you are using the original tag of `{webr}` instead of `{webr-r}`, 
+there is a known warning that will appear in the render processing output of:
 
 ```r
 Warning message:
@@ -160,10 +160,11 @@ In get_engine(options$engine) :
 This warning does not prevent or impact the ability of the `webr` filter to function. 
 Though, we would like to address it at some point since it is not aesthetically pleasing.
 
-
 ## Acknowledgements
 
 We appreciate the early testing feedback from [Eli E. Holmes](https://eeholmes.github.io/) and [Bob Rudis](https://rud.is/).
+
+We also appreciate the Quarto team assisting with [setting up a new code cell type](https://github.com/quarto-dev/quarto-cli/discussions/4761#discussioncomment-5336636).
 
 This repository builds ontop of the initial proof of concept for a standalone Quarto HTML document in:
 

--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.0.3
+version: 0.0.4
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/webr-demo.qmd
+++ b/webr-demo.qmd
@@ -8,9 +8,9 @@ filters:
 
 ## Demo
 
-This is a webr-enabled code cell in a Quarto HTML document.
+WebR-enabled code cell are established by using `{webr-r}` in a Quarto HTML document.
 
-```{webr}
+```{webr-r}
 1 + 1 
 ```
 
@@ -18,14 +18,14 @@ This is a webr-enabled code cell in a Quarto HTML document.
 
 ### Fit a linear regression model
 
-```{webr}
+```{webr-r}
 fit = lm(mpg ~ am, data = mtcars)
 summary(fit)
 ```
 
 ### Create a graph with base R
 
-```{webr}
+```{webr-r}
 plot(pressure)
 ```
 
@@ -36,7 +36,7 @@ plot(pressure)
 
 You can view what packages are available for webR by either executing the following R code (either with WebR or just R):
 
-```{webr}
+```{webr-r}
 available.packages(
     repos="https://repo.r-wasm.org/", 
     type="source")[,c("Package", "Version")]
@@ -50,7 +50,7 @@ Or, by navigating to the WebR repository:
 
 Installing `ggplot2` may take at least 2 minutes to run. 
 
-```{webr}
+```{webr-r}
 webr::install("ggplot2")
 ```
 
@@ -58,7 +58,7 @@ webr::install("ggplot2")
 
 Once `ggplot2` is loaded, then use the package as normal.
 
-```{webr}
+```{webr-r}
 library(ggplot2)
 
 p = ggplot(mpg, aes(class, hwy))
@@ -67,33 +67,39 @@ p + geom_boxplot()
 
 ### Define variables and re-use them in later cells
 
-```{webr}
+```{webr-r}
 name = "James"
 age = 42
 ```
 
 
-```{webr}
+```{webr-r}
 message(name, " is ", age, " years old!")
 ```
 
 
 ### Escape characters in a string
 
-```{webr}
+```{webr-r}
 seven_seas = "Ahoy, matey!\nLet's set sail for adventure!\n"
 seven_seas
 ```
 
 ### Anonymous function definition
 
-```{webr}
+```{webr-r}
 add_one <- \(x) x + 1
 add_one(2)
 ```
 
 ### Empty code cell
 
-```{webr}
+```{webr-r}
 
+```
+
+### Pre-rendered code cell
+
+```{r}
+message("Hello!")
 ```


### PR DESCRIPTION
We implemented a new engine name `webr-r` instead of the original `webr` engine to gain access to being able to run code cells inside of the Quarto document within VS Code and RStudio.

For more details, please see the custom cell engine discussion on the Quarto project discussion forum:

<https://github.com/quarto-dev/quarto-cli/discussions/4761#discussioncomment-5336636>