### PR TITLE
Set webR options from within Quarto Document YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ filters:
   - webr
 ```
 
-Then, place the code for `webr` in a code block marked with `{webr}`
+Then, place the R code for `webR` in a code block marked with `{webr-r}`
 
 ````markdown
 ---
@@ -52,9 +52,11 @@ summary(fit)
 ````
 
 
-When `quarto render` or `quarto preview` is called, the filter will execute under the `jupyter` compute engine if `engine: knitr` is not specified. 
+When `quarto render` or `quarto preview` is called, the filter will execute under `engine: knitr`. 
 During the execution, the filter adds two files to the working directory: `webr-worker.js` and `webr-serviceworker.js`. These files allow for the 
-webR session to be started and must be present with the rendered output.
+`webR` session to be started and must be present with the rendered output. 
+
+**Note:** If `engine: knitr` is not specified, then the `jupyter` compute engine will be used by default.
 
 ### Packages
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,16 @@ webr::install("ggplot2")
 
 The `quarto-webr` extension supports specifying the following `WebROptions` options:
 
-- `show-startup-message`: Display in the document header the state of WebR initialization. Default: `true`
-- `show-header-message`: Display in the document header whether COOP and COEP headers are in use for faster page loads. Default: `false`
 - `home-dir`: The WebAssembly user’s home directory and initial working directory ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir)). Default: `'/home/web_user'`.
-- `base-url`: The base URL used for downloading R WebAssembly binaries. ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir)). ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl)). Default: `'https://webr.r-wasm.org/[version]/'`.
+- `base-url`: The base URL used for downloading R WebAssembly binaries. ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl)). Default: `'https://webr.r-wasm.org/[version]/'`.
 - `service-worker-url`: The base URL from where to load JavaScript worker scripts when loading webR with the ServiceWorker communication channel mode ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#serviceworkerurl)). Default: `''`.
 
-Place these options underneath the `webr` entry in the documentation header, e.g.
+The extension also has native options for:
+
+- `show-startup-message`: Display in the document header the state of WebR initialization. Default: `true`
+- `show-header-message`: Display in the document header whether COOP and COEP headers are in use for faster page loads. Default: `false`
+
+For these options to be active, they must be placed underneath the `webr` entry in the documentation header, e.g.
 
 ```markdown
 ---

--- a/README.md
+++ b/README.md
@@ -58,19 +58,9 @@ webR session to be started and must be present with the rendered output.
 
 ### Packages
 
-By default, the `quarto-webr` extension avoids loading or requesting additional packages. Additional packages can be added by including:
-
-```r
-webr::install("package")
-```
-
-For example, to install `ggplot2`, you would need to use: 
-
-```r
-webr::install("ggplot2")
-```
-
-You can view what packages are available by either executing the following R code (either with WebR or just R):
+By default, the `quarto-webr` extension avoids loading or requesting additional packages. Additional packages can be added 
+when the document is first opened or on per-code cell basis. You can view what packages are available by either executing 
+the following R code (either with WebR or just R):
 
 ```r
 available.packages(repos="https://repo.r-wasm.org/", type="source")
@@ -79,6 +69,53 @@ available.packages(repos="https://repo.r-wasm.org/", type="source")
 Or, by navigating to the WebR repository:
 
 <https://github.com/r-wasm/webr-repo/blob/main/repo-packages>
+
+
+#### Install on document open
+
+Add to the document header YAML the `packages` key under `webr` with each package listed using an array, e.g. 
+
+```yaml
+---
+webr:
+  packages: ['ggplot2', 'dplyr']
+---
+```
+
+#### Install on an as needed basis
+
+Packages may also be installed inside of a code cell through the built-in [`webr::install()` function](https://docs.r-wasm.org/webr/latest/packages.html#example-installing-the-matrix-package). For example, to install `ggplot2`, you would need to use: 
+
+```r
+webr::install("ggplot2")
+```
+
+### Customizing webR from the Quarto Extension
+
+The `quarto-webr` extension supports specifying the following `WebROptions` options:
+
+- `show-startup-message`: Display in the document header the state of WebR initialization. Default: `true`
+- `show-header-message`: Display in the document header whether COOP and COEP headers are in use for faster page loads. Default: `false`
+- `home-dir`: The WebAssembly user’s home directory and initial working directory ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir)). Default: `'/home/web_user'`.
+- `base-url`: The base URL used for downloading R WebAssembly binaries. ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir)). ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl)). Default: `'https://webr.r-wasm.org/[version]/'`.
+- `service-worker-url`: The base URL from where to load JavaScript worker scripts when loading webR with the ServiceWorker communication channel mode ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#serviceworkerurl)). Default: `''`.
+
+Place these options underneath the `webr` entry in the documentation header, e.g.
+
+```markdown
+---
+title: WebR in Quarto HTML Documents
+format: html
+engine: knitr
+webr: 
+  show-startup-message: false
+  show-header-message: false
+  home-dir: '/home/r-user/'
+  packages: ['ggplot2', 'dplyr']
+filters:
+  - webr
+---
+```
 
 ## Known Hiccups
 
@@ -95,6 +132,8 @@ If `webr-worker.js` or `webr-serviceworker.js` are not found when the document l
 ├── webr-serviceworker.js
 └── webr-worker.js
 ```
+
+Still having trouble? Try specifying where the worker files are located using the `service-worker-url` option in the document's YAML header.
 
 ### Directly accessing rendered HTML
 

--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.0.4
+version: 0.1.0
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/template.qmd
+++ b/_extensions/webr/template.qmd
@@ -2,6 +2,13 @@
 title: "WebR-enabled code cell"
 format: html
 engine: knitr
+#webr:
+#  show-startup-message: false      # Display status of webR initialization
+#  show-header-message: false      # Check to see if COOP&COEP headers are set for speed.
+#  packages: ['ggplot2', 'dplyr'] # Pre-install dependencies
+#  home-dir: "/home/rstudio"      # Customize where the working directory is
+#  base-url: ''                   # Base URL used for downloading R WebAssembly binaries
+#  service-worker-url: ''         # URL from where to load JavaScript worker scripts when loading webR with the ServiceWorker communication channel.
 filters:
 - webr
 ---
@@ -10,15 +17,15 @@ filters:
 
 This is a webr-enabled code cell in a Quarto HTML document.
 
-```{webr}
+```{webr-r}
 1 + 1 
 ```
 
-```{webr}
+```{webr-r}
 fit = lm(mpg ~ am, data = mtcars)
 summary(fit)
 ```
 
-```{webr}
+```{webr-r}
 plot(pressure)
 ```

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -13,17 +13,97 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/6.65.7/mode/r/r.js"></script>
 <script type="module">
 
+  // Start a timer
+  const initializeWebRTimerStart = performance.now();
 
-  import { WebR } from "https://webr.r-wasm.org/v0.1.0/webr.mjs";
-  
-  
-  // Maybe return the `/` if needed in SW_URL?
-  globalThis.webR = new WebR();
+  // Determine if we need to install R packages
+  var installRPackagesList = [{{INSTALLRPACKAGESLIST}}];
+  // Check to see if we have an empty array, if we do set to skip the installation.
+  var setupRPackages = !(installRPackagesList.indexOf("") !== -1);
 
+  // Display a startup message?
+  var showStartupMessage = {{SHOWSTARTUPMESSAGE}};
+  var showHeaderMessage = {{SHOWHEADERMESSAGE}};
+  if (showStartupMessage) {
+
+    // Create the outermost div element
+    var quartoTitleMeta = document.createElement("div");
+    quartoTitleMeta.classList.add("quarto-title-meta");
+
+    // Create the first inner div element
+    var firstInnerDiv = document.createElement("div");
+
+    // Create the second inner div element with "WebR Status" heading 
+    // and contents
+    var secondInnerDiv = document.createElement("div");
+    secondInnerDiv.classList.add("quarto-title-meta-heading");
+    secondInnerDiv.innerText = "WebR Status";
+
+    // Add another inner div
+    var secondInnerDivContents = document.createElement("div");
+    secondInnerDivContents.classList.add("quarto-title-meta-contents");
+
+    // Describe the WebR state
+    var startupMessageWebR = document.createElement("p");
+    startupMessageWebR.innerText = "🟡 Loading...";
+    startupMessageWebR.setAttribute("id", "startup");
+
+    // Put everything together
+    secondInnerDivContents.appendChild(startupMessageWebR);
+
+    // Add a status indicator for COOP and COEP Headers
+    if (showHeaderMessage) {
+      var crossOriginMessage = document.createElement("p");
+      crossOriginMessage.innerText = `${crossOriginIsolated ? '🟢' : '🟡'} COOP & COEP Headers`;
+      crossOriginMessage.setAttribute("id", "coop-coep-header");
+      secondInnerDivContents.appendChild(crossOriginMessage);
+    }
+
+    firstInnerDiv.appendChild(secondInnerDiv);
+    firstInnerDiv.appendChild(secondInnerDivContents);
+    quartoTitleMeta.appendChild(firstInnerDiv);
+
+    // Add new element as last child in header element
+    var header = document.getElementsByTagName("header")[0];
+    header.appendChild(quartoTitleMeta);
+  }
+
+  // Retrieve the webr.mjs
+  import { WebR } from "https://webr.r-wasm.org/v0.1.1/webr.mjs";
+  
+  // Populate WebR options with defaults or new values based on 
+  // webr meta
+  globalThis.webR = new WebR({
+    "baseURL": "{{BASEURL}}",
+    "serviceWorkerUrl": "{{SERVICEWORKERURL}}",
+    "homedir": "{{HOMEDIR}}"
+  });
+
+  // Initialization WebR
   await globalThis.webR.init();
+
+  // Setup a shelter
   globalThis.webRCodeShelter = await new globalThis.webR.Shelter();
+
+  // Installing Packages
+  if (showStartupMessage && setupRPackages) {
+    // If initialized, but we have packages to install switch status
+    startupMessageWebR.innerText = "🟡 Installing package dependencies..."
+    // Install packages
+    await globalThis.webR.installPackages(installRPackagesList)
+  }
+
+  // Switch to allowing code to be executed
   document.querySelectorAll(".btn-webr").forEach((btn) => {
     btn.innerText = "Run code";
     btn.disabled = false;
   });
+
+  // Stop timer
+  const initializeWebRTimerEnd = performance.now();
+
+  if (showStartupMessage) {
+    // If initialized, switch to a green light
+    startupMessageWebR.innerText = "🟢 Ready!"
+  }
 </script>  

--- a/_extensions/webr/webr-serviceworker.js
+++ b/_extensions/webr/webr-serviceworker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.1.0/webr-serviceworker.js');
+importScripts('https://webr.r-wasm.org/v0.1.1/webr-serviceworker.js');

--- a/_extensions/webr/webr-worker.js
+++ b/_extensions/webr/webr-worker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.1.0/webr-worker.js');
+importScripts('https://webr.r-wasm.org/v0.1.1/webr-worker.js');

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -1,16 +1,135 @@
+----
+--- Setup variables for default initialization
+
 -- Define a variable to only include the initialization once
 local hasDoneWebRSetup = false
--- Define a counter variable
-local counter = 0
+
+--- Setup default initialization values
+-- Default values taken from:
+-- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html
+
+-- Define a base compatibile version
+local baseVersionWebR = "0.1.1"
+
+-- Define where WebR can be found
+local baseUrl = ""
+local serviceWorkerUrl = ""
+
+-- Define user directory
+local homeDir = "/home/web_user"
+
+-- Define whether a startup message should be displayed
+local showStartUpMessage = "true"
+
+-- Define whether header type messages should be displayed
+local showHeaderMessage = "false"
+
+-- Define an empty string if no packages need to be installed.
+local installRPackagesList = "''"
 ----
 
--- Read in the editor template
-function editorTemplateFile()
-  -- Establish a hardcoded path to where the webr-editor.html partial resides
+--- Setup variables for tracking number of code cells
+
+-- Define a counter variable
+local counter = 0
+
+----
+--- Process initialization
+
+-- Check if variable is present and not just the empty string
+function is_variable_empty(s)
+  return s == nil or s == ''
+end
+
+-- Parse the different webr options set in the YAML frontmatter, e.g.
+--
+-- ```yaml
+-- ----
+-- webr:
+--   base-url: https://webr.r-wasm.org/[version]
+--   service-worker-url: path/to/workers/{webr-serviceworker.js, webr-worker.js}
+-- ----
+-- ```
+--
+-- 
+function setWebRInitializationOptions(meta)
+
+  -- Let's explore the meta variable data! 
+  -- quarto.log.output(meta)
+  
+  -- Retrieve the webr options from meta
+  local webr = meta.webr
+
+  -- Does this exist? If not, just return meta as we'll just use the defaults.
+  if is_variable_empty(webr) then
+    return meta
+  end
+
+  -- The base URL used for downloading R WebAssembly binaries 
+  -- https://webr.r-wasm.org/[version]/webr.mjs
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl
+  if not is_variable_empty(webr["base-url"]) then
+    baseUrl = pandoc.utils.stringify(webr["base-url"])
+  end
+
+  -- The base URL from where to load JavaScript worker scripts when loading webR
+  -- with the ServiceWorker communication channel mode.
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#serviceworkerurl
+  if not is_variable_empty(webr["service-worker-url"]) then
+    serviceWorkerUrl = pandoc.utils.stringify(webr["service-worker-url"])
+  end
+
+  -- The WebAssembly user's home directory and initial working directory. Default: '/home/web_user'
+  -- Documentation:
+  -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir
+  if not is_variable_empty(webr['home-dir']) then
+    homeDir = pandoc.utils.stringify(webr["home-dir"])
+  end
+
+  -- Display a startup message indicating the WebR state at the top of the document.
+  if not is_variable_empty(webr['show-startup-message']) then
+    showStartUpMessage = pandoc.utils.stringify(webr["show-startup-message"])
+  end
+
+  -- Display a startup message indicating the WebR state at the top of the document.
+  if not is_variable_empty(webr['show-header-message']) then
+    showHeaderMessage = pandoc.utils.stringify(webr["show-header-message"])
+    if showHeaderMessage == "true" then
+      showStartUpMessage = "true"
+    end
+  end
+
+
+  -- Attempt to install different packages.
+  if not is_variable_empty(webr["packages"]) then
+    -- Create a custom list
+    local package_list = {}
+
+    -- Iterate through each list item and enclose it in quotes
+    for _, package_name in pairs(webr["packages"]) do
+      table.insert(package_list, "'" .. pandoc.utils.stringify(package_name) .. "'")
+    end
+
+    quarto.log.output(package_list)
+    quarto.log.output(table.concat(package_list, ', '))
+
+    installRPackagesList = table.concat(package_list, ", ")
+  end
+
+  
+  return meta
+end
+
+
+-- Obtain a template file
+function readTemplateFile(template)
+  -- Establish a hardcoded path to where the .html partial resides
   -- Note, this should be at the same level as the lua filter.
-  -- This is crazy fragile since lua lacks a directory representation (!?!?)
+  -- This is crazy fragile since Lua lacks a directory representation (!?!?)
   -- https://quarto.org/docs/extensions/lua-api.html#includes
-  local path = quarto.utils.resolve_path("webr-editor.html") 
+  local path = quarto.utils.resolve_path(template) 
 
   -- Let's hopefully read the template file... 
 
@@ -32,9 +151,18 @@ function editorTemplateFile()
   return content
 end
 
+-- Obtain the editor template file at webr-editor.html
+function editorTemplateFile()
+  return readTemplateFile("webr-editor.html")
+end
+
+-- Obtain the initialization template file at webr-init.html
+function initializationTemplateFile()
+  return readTemplateFile("webr-init.html")
+end
+
 -- Cache a copy of the template to avoid multiple read/writes.
 editor_template = editorTemplateFile()
-
 ----
 
 -- Define a function that escape control sequence
@@ -48,7 +176,85 @@ function escapeControlSequences(str)
   end)
 end
 
+-- Check if version is latest
+function isLatestVersion(str)
+  return str == "latest"
+end
+
+
+-- Verify the string is a valid version
+function isMajorMinorPatchFormat(version)
+  -- Create a regular expression pattern that matches:
+  -- major.minor.patch
+  local pattern = "^%d+%.%d+%.%d+$"
+
+  -- If the pattern matches, then we're set!
+  return string.match(version, pattern) ~= nil
+end
+
+function checkMajorMinorPatchVersionFormat(version_string)
+  -- Verify string matches a given format
+  if not isMajorMinorPatchFormat(version_string) then
+      error("Invalid version string: " .. version_string)
+  end
+  -- Empty return to use as enforcement
+  return 
+end
+
+-- Compare versions
+function compareMajorMinorPatchVersions(v1, v2)
+
+  -- Enforce a version string
+  checkMajorMinorPatchVersionFormat(v1)
+  checkMajorMinorPatchVersionFormat(v2)
+
+  -- Extract version details
+  local v1_major, v1_minor, v1_patch = v1:match("(%d+)%.(%d+)%.(%d+)")
+  local v2_major, v2_minor, v2_patch = v2:match("(%d+)%.(%d+)%.(%d+)")
+  
+  -- Perform a comparison check on the dot releases, such that:
+  -- v1 > v2 returns 1 
+  -- v2 > v1 returns -1 
+  -- v1 == v2 returns 0
+  if tonumber(v1_major) > tonumber(v2_major) then
+    return 1
+  elseif tonumber(v2_major) > tonumber(v1_major) then
+    return -1
+  elseif tonumber(v1_minor) > tonumber(v2_minor) then
+    return 1
+  elseif tonumber(v2_minor) > tonumber(v1_minor) then
+    return -1
+  elseif tonumber(v1_patch) > tonumber(v2_patch) then
+    return 1
+  elseif tonumber(v2_patch) > tonumber(v1_patch) then
+    return -1
+  else
+    return 0
+  end
+end
 ----
+
+function initializationWebR()
+
+  -- Setup different WebR specific initialization variables
+  local substitutions = {
+    ["SHOWSTARTUPMESSAGE"] = showStartUpMessage, -- tostring()
+    ["SHOWHEADERMESSAGE"] = showHeaderMessage,
+    ["BASEURL"] = baseUrl, 
+    ["SERVICEWORKERURL"] = serviceWorkerUrl, 
+    ["HOMEDIR"] = homeDir,
+    ["INSTALLRPACKAGESLIST"] = installRPackagesList
+    -- ["VERSION"] = baseVersionWebR
+  }
+  
+  -- Make sure we perform a copy
+  local initializationTemplate = initializationTemplateFile()
+
+  -- Make the necessary substitutions
+  local initializedWebRConfiguration = substitute_in_file(initializationTemplate, substitutions)
+
+  return initializedWebRConfiguration
+end
 
 -- Setup WebR's pre-requisites once per document.
 function ensureWebRSetup()
@@ -60,10 +266,12 @@ function ensureWebRSetup()
   
   -- Otherwise, let's include the initialization script _once_
   hasDoneWebRSetup = true
+
+  local initializedConfigurationWebR = initializationWebR()
   
   -- Insert the web initialization
   -- https://quarto.org/docs/extensions/lua-api.html#includes
-  quarto.doc.include_file("in-header", "webr-init.html")
+  quarto.doc.include_text("in-header", initializedConfigurationWebR)
 
   -- Copy the two web workers into the directory
   -- https://quarto.org/docs/extensions/lua-api.html#dependencies
@@ -82,67 +290,72 @@ function substitute_in_file(contents, substitutions)
   return contents
 end
 
+function enableWebRCodeCell(el)
+      
+  -- Let's see what's going on here:
+  -- quarto.log.output(el)
+  
+  -- Should display the following elements:
+  -- https://pandoc.org/lua-filters.html#type-codeblock
+  
+  -- Verify the element has attributes and the document type is HTML
+  -- not sure if this will work with an epub (may need html:js)
+  if el.attr and quarto.doc.is_format("html") then
+
+    -- Check to see if any form of the {webr} tag is present 
+
+    -- Look for the original compute cell type `{webr}` 
+    -- If the compute engine is:
+    -- - jupyter: this appears as `{webr}` 
+    -- - knitr: this appears as `webr`
+    --  since the later dislikes custom engines
+    local originalEngine = el.attr.classes:includes("{webr}") or el.attr.classes:includes("webr")
+
+    -- Check for the new engine syntax that allows for the cell to be 
+    -- evaluated in VS Code or RStudio editor views, c.f.
+    -- https://github.com/quarto-dev/quarto-cli/discussions/4761#discussioncomment-5336636
+    local newEngine = el.attr.classes:includes("{webr-r}")
+    
+    if (originalEngine or newEngine) then
+      
+      -- Make sure we've initialized the code block
+      ensureWebRSetup()
+
+      -- Modify the counter variable each time this is run to create
+      -- unique code cells
+      counter = counter + 1
+      
+      -- 7 is the default height and width for knitr. But, that doesn't translate to pixels.
+      -- So, we have 504 and 360 respectively.
+      -- Should we check the attributes for this value? Seems odd.
+      -- https://yihui.org/knitr/options/
+      local substitutions = {
+        ["WEBRCOUNTER"] = counter, 
+        ["WIDTH"] = 504,
+        ["HEIGHT"] = 360,
+        ["WEBRCODE"] = escapeControlSequences(el.text)
+      }
+      
+      -- Make sure we perform a copy
+      local copied_editor_template = editor_template
+
+      -- Make the necessary substitutions
+      local webr_enabled_code_cell = substitute_in_file(copied_editor_template, substitutions)
+
+      -- Return the modified HTML template as a raw cell
+      return pandoc.RawInline('html', webr_enabled_code_cell)
+    end
+  end
+  -- Allow for a pass through in other languages
+  return el
+end
+
 return {
   {
-    CodeBlock = function(el)
-      
-      -- Let's see what's going on here:
-      -- quarto.log.output(el)
-      
-      -- Should display the following elements:
-      -- https://pandoc.org/lua-filters.html#type-codeblock
-      
-      -- Verify the element has attributes and the document type is HTML
-      -- not sure if this will work with an epub (may need html:js)
-      if el.attr and quarto.doc.is_format("html") then
-
-        -- Check to see if any form of the {webr} tag is present 
-
-        -- Look for the original compute cell type `{webr}` 
-        -- If the compute engine is:
-        -- - jupyter: this appears as `{webr}` 
-        -- - knitr: this appears as `webr`
-        --  since the later dislikes custom engines
-        local originalEngine = el.attr.classes:includes("{webr}") or el.attr.classes:includes("webr")
-
-        -- Check for the new engine syntax that allows for the cell to be 
-        -- evaluated in VS Code or RStudio editor views, c.f.
-        -- https://github.com/quarto-dev/quarto-cli/discussions/4761#discussioncomment-5336636
-        local newEngine = el.attr.classes:includes("{webr-r}")
-        
-        if (originalEngine or newEngine) then
-          
-          -- Make sure we've initialized the code block
-          ensureWebRSetup()
-
-          -- Modify the counter variable each time this is run to create
-          -- unique code cells
-          counter = counter + 1
-          
-          -- 7 is the default height and width for knitr. But, that doesn't translate to pixels.
-          -- So, we have 504 and 360 respectively.
-          -- Should we check the attributes for this value? Seems odd.
-          -- https://yihui.org/knitr/options/
-          local substitutions = {
-            ["WEBRCOUNTER"] = counter, 
-            ["WIDTH"] = 504,
-            ["HEIGHT"] = 360,
-            ["WEBRCODE"] = escapeControlSequences(el.text)
-          }
-          
-          -- Make sure we perform a copy
-          local copied_editor_template = editor_template
-
-          -- Make the necessary substitutions
-          local webr_enabled_code_cell = substitute_in_file(copied_editor_template, substitutions)
-
-          -- Return the modified HTML template as a raw cell
-          return pandoc.RawInline('html', webr_enabled_code_cell)
-        end
-      end
-      -- Allow for a pass through in other languages
-      return el
-    end
+    Meta = setWebRInitializationOptions
+  }, 
+  {
+    CodeBlock = enableWebRCodeCell
   }
 }
 

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -112,9 +112,6 @@ function setWebRInitializationOptions(meta)
       table.insert(package_list, "'" .. pandoc.utils.stringify(package_name) .. "'")
     end
 
-    quarto.log.output(package_list)
-    quarto.log.output(table.concat(package_list, ', '))
-
     installRPackagesList = table.concat(package_list, ", ")
   end
 

--- a/webr-demo.qmd
+++ b/webr-demo.qmd
@@ -98,6 +98,13 @@ add_one(2)
 
 ```
 
+### Prior code cell
+
+```{webr}
+
+```
+
+
 ### Pre-rendered code cell
 
 ```{r}


### PR DESCRIPTION
This PR implements the required pandoc lua filter logic to retrieve metadata from the document's YAML headers. The extension now supports the following [WebR.WebROptions](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html):

- `home-dir`: The WebAssembly user’s home directory and initial working directory ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#homedir)). Default: `'/home/web_user'`.
- `base-url`: The base URL used for downloading R WebAssembly binaries. ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#baseurl)). Default: `'https://webr.r-wasm.org/[version]/'`.
- `service-worker-url`: The base URL from where to load JavaScript worker scripts when loading webR with the ServiceWorker communication channel mode ([`Documentation`](https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#serviceworkerurl)). Default: `''`.

The extension now has the following _native_ options:


- `show-startup-message`: Display in the document header the state of WebR initialization. Default: `true`
- `show-header-message`: Display in the document header whether COOP and COEP headers are in use for faster page loads. Default: `false`

