### PR TITLE
Re-work adding service worker dependencies from `add_format_resource()` to `add_html_dependency()`.

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.1.0
+version: 0.2.1
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -195,7 +195,7 @@ function checkMajorMinorPatchVersionFormat(version_string)
       error("Invalid version string: " .. version_string)
   end
   -- Empty return to use as enforcement
-  return 
+  return false
 end
 
 -- Compare versions
@@ -272,8 +272,20 @@ function ensureWebRSetup()
 
   -- Copy the two web workers into the directory
   -- https://quarto.org/docs/extensions/lua-api.html#dependencies
-  quarto.doc.add_format_resource("webr-worker.js")	
-  quarto.doc.add_format_resource("webr-serviceworker.js")	
+
+  quarto.doc.add_html_dependency({
+    name = "webr-worker",
+    version = baseVersionWebR,
+    seviceworkers = {"webr-worker.js"}, -- Kept to avoid error text.
+    serviceworkers = {"webr-worker.js"}
+  })
+
+  quarto.doc.add_html_dependency({
+    name = "webr-serviceworker",
+    version = baseVersionWebR,
+    seviceworkers = {"webr-serviceworker.js"}, -- Kept to avoid error text.
+    serviceworkers = {"webr-serviceworker.js"}
+  })
 end
 
 -- Define a function to replace keywords given by {{ WORD }}


### PR DESCRIPTION
We've switched from `add_format_resource()` to `add_html_dependency()` due to the latter most likely allowing the `webr-serviceworker.js` and `webr-worker.js` files to persist on <https://quarto.pub>

Moreover, we're supplying both `seviceworkers` and `serviceworkers` to avoid an error message that requires Quarto v1.4.300+ to resolve, c.f. https://github.com/quarto-dev/quarto-cli/pull/6490

