### PR TITLE
Update the default version / baseline version of webr to v0.2.0

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.2.1
+version: 0.3.0
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/webr-editor.html
+++ b/_extensions/webr/webr-editor.html
@@ -79,15 +79,15 @@
     // Initialize webR
     await globalThis.webR.init();
 
-    // Setup a webR canvas
-    await webR.evalRVoid("canvas(width={{WIDTH}}, height={{HEIGHT}})");
+    // Setup a webR canvas by making a namespace call into the {webr} package
+    await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
 
     // Capture output data from evaluating the code
     const result = await webRCodeShelter.captureR(codeToRun, {
       withAutoprint: true,
       captureStreams: true,
-      captureConditions: false,
-      env: webR.objs.emptyEnv,
+      captureConditions: false//,
+      // env: webR.objs.emptyEnv, // maintain a global environment for webR v0.2.0
     });
 
     // Start attempting to parse the result data
@@ -106,8 +106,13 @@
 
       // Output each image stored
       msgs.forEach(msg => {
-        if (msg.type === "canvasExec") {
-          if (!canvas) {
+        // Determine if old canvas can be used or a new canvas is required.
+        if (msg.type === 'canvas'){
+          // Add image to the current canvas
+          if (msg.data.event === 'canvasImage') {
+            canvas.getContext('2d').drawImage(msg.data.image, 0, 0);
+          } else if (msg.data.event === 'canvasNewPage') {
+            // Generate a new canvas element
             canvas = document.createElement("canvas");
             canvas.setAttribute("width", 2 * {{WIDTH}});
             canvas.setAttribute("height", 2 * {{HEIGHT}});
@@ -115,7 +120,6 @@
             canvas.style.display = "block";
             canvas.style.margin = "auto";
           }
-          Function(`this.getContext("2d").${msg.data}`).bind(canvas)();
         }
       });
 

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -79,7 +79,7 @@
   }
 
   // Retrieve the webr.mjs
-  import { WebR } from "https://webr.r-wasm.org/v0.1.1/webr.mjs";
+  import { WebR } from "https://webr.r-wasm.org/v0.2.0/webr.mjs";
 
   // Populate WebR options with defaults or new values based on 
   // webr meta

--- a/_extensions/webr/webr-serviceworker.js
+++ b/_extensions/webr/webr-serviceworker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.1.1/webr-serviceworker.js');
+importScripts('https://webr.r-wasm.org/v0.2.0/webr-serviceworker.js');

--- a/_extensions/webr/webr-worker.js
+++ b/_extensions/webr/webr-worker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.1.1/webr-worker.js');
+importScripts('https://webr.r-wasm.org/v0.2.0/webr-worker.js');

--- a/webr-demo.qmd
+++ b/webr-demo.qmd
@@ -51,11 +51,14 @@ Or, by navigating to the WebR repository:
 
 #### Installing a Package
 
-Installing `ggplot2` may take at least 2 minutes to run. 
+Installing a package interactively is done using `webr::install()` inside of a `{webr-r}` code cell. 
+
+**Note:** Installing `ggplot2` may take at least 2 minutes if COEP & COOP headers are not set.
 
 ```{webr-r}
 webr::install("ggplot2")
 ```
+
 
 #### Using a Package
 


### PR DESCRIPTION
Moves the `quarto-webr` extension to the new basline.