### PR TITLE
Monaco Editor Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /.luarc.json
+*_files
+webr-worker.js
+webr-serviceworker.js
+webr-*.html

--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.3.1
+version: 0.3.2
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/monaco-editor-init.html
+++ b/_extensions/webr/monaco-editor-init.html
@@ -1,0 +1,10 @@
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js"></script>
+<script type="module">
+
+  // Configure the Monaco Editor's loader
+  require.config({
+    paths: {
+      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs'
+    }
+  });
+</script>

--- a/_extensions/webr/webr-editor.html
+++ b/_extensions/webr/webr-editor.html
@@ -30,21 +30,6 @@
       hideCursorInOverviewRuler: true  // Remove cursor indictor in right hand side scroll bar
     });
 
-    // Add a keydown event listener for Shift+Enter using the addCommand method
-    editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, function () {
-      // Code to run when Shift+Enter is pressed
-      console.log(editor.getValue().length)
-      executeCode(editor.getValue());
-    });
-
-    // Add a keydown event listener for Ctrl+Enter to run selected code
-    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, function () {
-      // Get the selected text from the editor
-      const selectedText = editor.getModel().getValueInRange(editor.getSelection());
-      // Code to run when Ctrl+Enter is pressed (run selected code)
-      executeCode(selectedText);
-    });
-
     // Dynamically modify the height of the editor window if new lines are added.
     let ignoreEvent = false;
     const updateHeight = () => {
@@ -61,6 +46,32 @@
         ignoreEvent = false;
       }
     };
+
+    // Registry of keyboard shortcuts that should be re-added to each editor window
+    // when focus changes.
+    const addWebRKeyboardShortCutCommands = () => {
+      // Add a keydown event listener for Shift+Enter to run all code in cell
+      editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, () => {
+
+        // Retrieve all text inside the editor
+        executeCode(editor.getValue());
+      });
+
+      // Add a keydown event listener for CMD/Ctrl+Enter to run selected code
+      editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter, () => {
+        // Get the selected text from the editor
+        const selectedText = editor.getModel().getValueInRange(editor.getSelection());
+        // Code to run when Ctrl+Enter is pressed (run selected code)
+        executeCode(selectedText);
+      });
+    }
+
+    // Register an on focus event handler for when a code cell is selected to update
+    // what keyboard shortcut commands should work.
+    // This is a workaround to fix a regression that happened with multiple
+    // editor windows since Monaco 0.32.0 
+    // https://github.com/microsoft/monaco-editor/issues/2947
+    editor.onDidFocusEditorText(addWebRKeyboardShortCutCommands);
 
     // Register an on change event for when new code is added to the editor window
     editor.onDidContentSizeChange(updateHeight);

--- a/_extensions/webr/webr-editor.html
+++ b/_extensions/webr/webr-editor.html
@@ -33,6 +33,7 @@
     // Add a keydown event listener for Shift+Enter using the addCommand method
     editor.addCommand(monaco.KeyMod.Shift | monaco.KeyCode.Enter, function () {
       // Code to run when Shift+Enter is pressed
+      console.log(editor.getValue().length)
       executeCode(editor.getValue());
     });
 

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -1,4 +1,5 @@
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.31.0/min/vs/editor/editor.main.css" />
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css" />
+
 <style>
   .monaco-editor pre {
     background-color: unset !important;
@@ -10,16 +11,16 @@
     border-bottom-right-radius: 0;
   }
 </style>
-<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.31.0/min/vs/loader.js"></script>
+
+<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js"></script>
 <script type="module">
 
   // Configure the Monaco Editor's loader
   require.config({
     paths: {
-      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.31.0/min/vs'
+      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs'
     }
   });
-
 
   // Start a timer
   const initializeWebRTimerStart = performance.now();

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -12,15 +12,7 @@
   }
 </style>
 
-<script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js"></script>
 <script type="module">
-
-  // Configure the Monaco Editor's loader
-  require.config({
-    paths: {
-      'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs'
-    }
-  });
 
   // Start a timer
   const initializeWebRTimerStart = performance.now();

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -270,6 +270,9 @@ function ensureWebRSetup()
   -- https://quarto.org/docs/extensions/lua-api.html#includes
   quarto.doc.include_text("in-header", initializedConfigurationWebR)
 
+  -- Insert the monaco editor initialization
+  quarto.doc.include_file("before-body", "monaco-editor-init.html")
+
   -- Copy the two web workers into the directory
   -- https://quarto.org/docs/extensions/lua-api.html#dependencies
 


### PR DESCRIPTION
This PR contains three important changes to the code editor used by `quarto-webr`. In particular, we have:

1. Updating the MonacoEditor from v0.31.0 to v0.43.0. 
2. Re-arranging the load order of Monaco to avoid issues with Safari (fix #21)
3. Fixing the Keybinding issue by re-mapping the keyboard shortcuts on editor focus (fix #28)
