### PR TITLE
Hidden code cells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 *_files
 webr-worker.js
 webr-serviceworker.js
-webr-*.html
+/webr-*.html

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 webr-worker.js
 webr-serviceworker.js
 /webr-*.html
+*.csv

--- a/_extensions/webr/webr-context-internal.html
+++ b/_extensions/webr/webr-context-internal.html
@@ -1,0 +1,5 @@
+<script type="module">
+await globalThis.webR.evalRVoid(`
+{{WEBRCODE}}
+`)
+</script>	

--- a/update-quarto-dev.sh
+++ b/update-quarto-dev.sh
@@ -1,7 +1,8 @@
-QUARTO_VERSION="1.4.349"
+QUARTO_VERSION="1.4.358"
 
 wget -O quarto-latest.deb https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/quarto-${QUARTO_VERSION}-linux-amd64.deb
 
 sudo dpkg -i ./quarto-latest.deb
 
 rm quarto-latest.deb
+

--- a/webr-demo.qmd
+++ b/webr-demo.qmd
@@ -16,6 +16,12 @@ webR-enabled code cell are established by using `{webr-r}` in a Quarto HTML docu
 1 + 1
 ```
 
+For instance, the above `webr`-enabled code cell was created by typing into the Quarto document:
+
+```{{webr-r}}
+1 + 1
+```
+
 ## Sample cases
 
 ### Fit a linear regression model
@@ -98,11 +104,14 @@ add_one <- \(x) x + 1
 add_one(2)
 ```
 
+
+
 ### Empty code cell
 
 ```{webr-r}
 
 ```
+
 
 ### Prior code cell
 

--- a/webr-internal-cell.qmd
+++ b/webr-internal-cell.qmd
@@ -78,3 +78,72 @@ webr:
 ---
 ```
 :::
+
+## Hidden Solution Checking of Student Work
+
+:::{.callout-warning}
+Be advised that any solution written into a webR hidden code cell can be obtained by viewing the document's HTML source. **Please _avoid_ using this option for formal assessment (exams, quizzes, homework, ...).**
+:::
+
+Lastly, the webR document can be used to check student answers. We can make available an answer key and a comparison function within the document.
+
+For instance, the solution data frame might look a bit like:
+
+```{{webr-r}}
+#| context: hidden
+answer_frame <- data.frame(
+  problem = c("1a", "1b", "2"),
+  answer = c(10, 2, 3/16),
+  tol = c(0.001, 0, 1/32)
+)
+```
+
+Next, we can define an internal check function like so:
+
+```{{webr-r}}
+#| context: hidden
+check <- function(problem, answer) {
+  aframe <- answer_frame
+  if(!problem %in% aframe$problem) stop(paste0("Please enter a valid problem. (", paste0(aframe$problem, collapse = ","), ")"))
+
+  solution <- aframe[which(aframe$problem == problem), "answer"]
+
+  ifelse(
+    all.equal(answer, solution, tolerance = 0.001) == TRUE,
+              "Correct! Well done.",
+              "Incorrect! Good attempt. Let's try again?")
+}
+```
+
+```{webr-r}
+#| context: hidden
+answer_frame <- data.frame(
+  problem = c("1a", "1b", "2"),
+  answer = c(10, 2, 3/16),
+  tol = c(0.001, 0, 1/32)
+)
+
+check <- function(problem, answer) {
+  aframe <- answer_frame
+  if(!problem %in% aframe$problem) stop(paste0("Please enter a valid problem. (", paste0(aframe$problem, collapse = ","), ")"))
+
+  solution <- aframe[which(aframe$problem == problem), "answer"]
+
+  ifelse(
+    all.equal(answer, solution, tolerance = 0.001) == TRUE,
+              "Correct! Well done.",
+              "Incorrect! Good attempt. Let's try again?")
+}
+```
+
+Students can then compare their answers to the answer key by using the `check()` function.
+
+Consider the question: 
+
+> What is 9 + 1? 
+
+```{webr-r}
+student_solution = 11
+
+check(problem = "1a", answer = student_solution)
+```

--- a/webr-internal-cell.qmd
+++ b/webr-internal-cell.qmd
@@ -1,0 +1,80 @@
+---
+title: "Hidden webR code cells"
+format: 
+  html:
+    toc: true
+engine: knitr
+filters:
+- webr
+---
+
+## Hidden Evaluation without Output
+
+In this example, we create a hidden setup code cell within the document by using the special comment of `#| context: setup`. The setup code cell executes code in the background and _does not_ display the code or its output.
+
+```{{webr-r}}
+#| context: setup
+meaning_of_life = 42
+```
+
+Thus, we have pre-loaded the `meaning_of_life` variable. So, if we run the next code cell, then we will see the value of `meaning_of_life` being displayed as `42` instead of an error.
+
+```{webr-r}
+#| context: setup
+meaning_of_life = 42
+```
+
+
+```{webr-r}
+meaning_of_life
+```
+
+::: {.callout-caution}
+Be advised that the contents of the hidden code cell is displayed if the web page's source is viewed.
+:::
+
+## Hidden Loading of a Dataset
+
+Outside of just specifying a single variable, we can use the setup hidden code cell to pre-load and wrangle an entire data set. This allows for students to directly interact with a loaded data set.
+
+```{{webr-r}}
+#| context: hidden
+
+# Download a data set
+download.file(
+  'https://raw.githubusercontent.com/coatless/raw-data/main/penguins.csv',
+  'penguins.csv'
+)
+
+# Read data
+df = read.csv("penguins.csv")
+```
+
+```{webr-r}
+#| context: setup
+
+# Download a data set
+download.file(
+  'https://raw.githubusercontent.com/coatless/raw-data/main/penguins.csv',
+  'penguins.csv'
+)
+
+# Read data
+df = read.csv("penguins.csv")
+```
+
+```{webr-r}
+# Show the head of the data
+head(df)
+```
+
+::: {.callout-note}
+If the setup code needs the present of R packages, we suggest specifying the required packages in the document's YAML. This option communicates to the end user that the webpage is not yet ready to explore through a clear status update at the top. For example, we could add `dplyr` and `ggplot2` using:
+
+```yaml
+---
+webr:
+  packages: ['ggplot2', 'dplyr']
+---
+```
+:::


### PR DESCRIPTION
This PR is long overdue; but, it's landed at long last.

The main issue here is the Quarto code cell options do _not_ persist when we reach the Lua filter stage. Thus, we needed to devise a new keyword (`context`) that is not already in use by Quarto and determine a way to extract the code cell comments from the `CodeBlock`'s `text` value. The logic for the last part is available in [`extractCodeBlockOptions()`](https://github.com/coatless/quarto-webr/commit/f514eed00139173308e9bcd59424772a1b22ff23#diff-f54aec1905d4e2d44dbfce99ee9e54cdaa83f37b54a9119b8f68636ed23b0463R313) cell.

To use the new hidden code cell feature, the document should have the code cell defined with `#| context: setup` like so:

````md
```{webr-r}
#| context: setup

my_hidden_variable = 11
```
````

Close #25 and Close #11
