### PR TITLE
Fix error on missing title

### DIFF
--- a/_extensions/webr/monaco-editor-init.html
+++ b/_extensions/webr/monaco-editor-init.html
@@ -1,5 +1,5 @@
 <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/loader.js"></script>
-<script type="module">
+<script type="module" id="webr-monaco-editor-init">
 
   // Configure the Monaco Editor's loader
   require.config({

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -97,7 +97,21 @@
 
     // Add new element as last child in header element
     var header = document.getElementById("title-block-header");
-    header.appendChild(quartoTitleMeta);
+
+    // Check if the header option is present or missing
+    if(header) {
+      // If present, directly append the child element.
+      header.appendChild(quartoTitleMeta);
+    } else {
+      // Attempt to place the new element inside a header _after_ the Monaco initialization
+      var monacoScript = document.getElementById("webr-monaco-editor-init");
+      var header = document.createElement("header");
+      header.setAttribute("id", "title-block-header");
+      // Now attempt to add the webR area to the title
+      header.appendChild(quartoTitleMeta);
+      // Include the header after the script tag
+      monacoScript.after(header);
+    }
   }
 
   // Retrieve the webr.mjs


### PR DESCRIPTION
This PR fixes webR failing to initialize if we are unable to detect Quarto's `"title-block-header"`. 

With a `title` element present we have: 

```
<header id="title-block-header" class="quarto-title-block default"></header>
```

Without the `title` element present, we have: 
 
No header...

We now check if the element exists and, then, append. If the header element is missing, we create a header and add the necessary ID but skip adding the class values to place the status icon.

<img width="818" alt="example-with-no-title" src="https://github.com/coatless/quarto-webr/assets/833642/732bc1d3-6d70-4d0f-a5f4-1e26d731c208">

Close #37 
