### PR TITLE
Add a GIL

### DIFF
--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -1,4 +1,4 @@
-<button class="btn btn-default btn-webr" disabled type="button" id="webr-run-button-{{WEBRCOUNTER}}">Loading
+<button class="btn btn-default btn-webr" disabled type="button" id="webr-run-button-{{WEBRCOUNTER}}">🟡 Loading
   webR...</button>
 <div id="webr-editor-{{WEBRCOUNTER}}"></div>
 <div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
@@ -118,6 +118,14 @@
     // Disable run button for code cell active
     runButton.disabled = true;
 
+    // Disallowing execution of other code cells
+    document.querySelectorAll(".btn-webr").forEach((btn) => {
+      btn.disabled = true;
+    });
+
+    // Emphasize the active code cell
+    runButton.innerHTML = '<i class="fa-solid fa-spinner fa-spin" style="color: #7894c4;"></i> <span>Run Code</span>';
+
     // Create a canvas variable for graphics
     let canvas = undefined;
 
@@ -193,8 +201,15 @@
     } finally {
       // Clean up the remaining code
       webRCodeShelter.purge();
-      runButton.disabled = false;
     }
+
+    // Switch to allowing execution of code
+    document.querySelectorAll(".btn-webr").forEach((btn) => {
+      btn.disabled = false;
+    });
+
+    // Revert to the initial code cell state
+    runButton.innerHTML = '<i class="fa-solid fa-play" style="color: #0d9c29;"></i> <span>Run Code</span>';
   }
 
   // Add a click event listener to the run button

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -1,5 +1,5 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.43.0/min/vs/editor/editor.main.css" />
-
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <style>
   .monaco-editor pre {
     background-color: unset !important;
@@ -139,13 +139,6 @@
     // Install packages
     await globalThis.webR.installPackages(installRPackagesList)
   }
-
-  // Switch to allowing code to be executed
-  document.querySelectorAll(".btn-webr").forEach((btn) => {
-    btn.innerText = "Run code";
-    btn.disabled = false;
-  });
-
   // Stop timer
   const initializeWebRTimerEnd = performance.now();
 
@@ -153,4 +146,11 @@
     // If initialized, switch to a green light
     startupMessageWebR.innerText = "🟢 Ready!"
   }
+  
+  // Switch to allowing code to be executed
+  document.querySelectorAll(".btn-webr").forEach((btn) => {
+    btn.innerHTML = '<i class="fa-solid fa-play" style="color: #0d9c29;"></i> <span>Run Code</span>';
+    btn.disabled = false;
+  });
+
 </script>

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -10,6 +10,12 @@ format:
 
 # 0.3.7: ??? (????)
 
+## Features
+
+- Added a Global Interpreter Lock (GIL) to ensures that only one code cell runs at a time, preventing simultaneous execution conflicts.
+  - With this enhancement, you can now enjoy smoother and more predictable execution of your code, without interference from concurrently running code cells.
+- Added a visual spinning indicator to emphasize what code cell is currently running.
+
 ## Documentation
 
 - Added an [`examples/` directory](https://github.com/coatless/quarto-webr/tree/main/examples) containing examples for [HTML Documents](), [Books](), and [Websites](). ([#53](https://github.com/coatless/quarto-webr/issues/53))


### PR DESCRIPTION
In this PR, we add new protection against running multiple code cells when a code cell is already running through a GIL.

![Demo showing the global "lock" feature when a single code cell is running](https://github.com/coatless/quarto-webr/assets/833642/0a57e6d1-795b-44b7-afc2-ca76600fee4d)


The downside is we now have a dependence on FontAwesome for the spinning logo. 

Close #64 