### PR TITLE
Improve the package installation status bar

### DIFF
--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -115,8 +115,6 @@
 
   // Function to execute the code (accepts code as an argument)
   async function executeCode(codeToRun) {
-    // Disable run button for code cell active
-    runButton.disabled = true;
 
     // Disallowing execution of other code cells
     document.querySelectorAll(".btn-webr").forEach((btn) => {
@@ -124,7 +122,7 @@
     });
 
     // Emphasize the active code cell
-    runButton.innerHTML = '<i class="fa-solid fa-spinner fa-spin" style="color: #7894c4;"></i> <span>Run Code</span>';
+    runButton.innerHTML = '<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Run Code</span>';
 
     // Create a canvas variable for graphics
     let canvas = undefined;
@@ -209,7 +207,7 @@
     });
 
     // Revert to the initial code cell state
-    runButton.innerHTML = '<i class="fa-solid fa-play" style="color: #0d9c29;"></i> <span>Run Code</span>';
+    runButton.innerHTML = '<i class="fa-solid fa-play qwebr-icon-run-code"></i> <span>Run Code</span>';
   }
 
   // Add a click event listener to the run button

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -5,6 +5,14 @@
     background-color: unset !important;
   }
 
+  .qwebr-icon-status-spinner {
+    color: #7894c4;
+  }
+
+  .qwebr-icon-run-code {
+    color: #0d9c29
+  }
+
   .btn-webr {
     background-color: #EEEEEE;
     border-bottom-left-radius: 0;
@@ -134,11 +142,25 @@
 
   // Installing Packages
   if (showStartupMessage && setupRPackages) {
-    // If initialized, but we have packages to install switch status
-    startupMessageWebR.innerText = "🟡 Installing package dependencies..."
-    // Install packages
-    await globalThis.webR.installPackages(installRPackagesList)
+
+    // Determine number of packages to install
+    const nInstallPackages = installRPackagesList.length
+
+    // Iterate through list of packages
+    for (let i = 0; i < nInstallPackages; i++) {
+
+      // Retrieve the package
+      const activePackage = installRPackagesList[i];
+
+      // Update status of package installs
+      startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing ${i + 1} of ${nInstallPackages} packages: ${activePackage}</span>`;
+
+      // Install the package
+      await globalThis.webR.installPackages(activePackage)
+    }
+
   }
+
   // Stop timer
   const initializeWebRTimerEnd = performance.now();
 
@@ -149,7 +171,7 @@
   
   // Switch to allowing code to be executed
   document.querySelectorAll(".btn-webr").forEach((btn) => {
-    btn.innerHTML = '<i class="fa-solid fa-play" style="color: #0d9c29;"></i> <span>Run Code</span>';
+    btn.innerHTML = '<i class="fa-solid fa-play qwebr-icon-run-code"></i> <span>Run Code</span>';
     btn.disabled = false;
   });
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -8,13 +8,14 @@ format:
     toc: true
 ---
 
-# 0.3.7: ??? (????)
+# 0.3.7: Mutex On, Mutex Off (????)
 
 ## Features
 
 - Added a Global Interpreter Lock (GIL) to ensures that only one code cell runs at a time, preventing simultaneous execution conflicts.
   - With this enhancement, you can now enjoy smoother and more predictable execution of your code, without interference from concurrently running code cells.
 - Added a visual spinning indicator to emphasize what code cell is currently running.
+- Improved status updates about installing R packages specified in the document's `package` key.
 
 ## Documentation
 


### PR DESCRIPTION
Switched from using a solid yellow light with static text to emphasizing the number of packages and a font-awesome spinner.

![improved-package-installation-status](https://github.com/coatless/quarto-webr/assets/833642/41f0a63a-8849-4e5d-b320-2385dd569081)


Close provide a better indicator of package installation #45