### PR TITLE
Localized webR

### DIFF
--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -123,7 +123,7 @@
   }
 
   // Retrieve the webr.mjs
-  import { WebR, ChannelType } from "https://webr.r-wasm.org/v0.2.1/webr.mjs";
+  import { WebR, ChannelType } from "{{BASEURL}}webr.mjs";
 
   // Populate WebR options with defaults or new values based on 
   // webr meta

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -12,7 +12,7 @@ local hasDoneWebRSetup = false
 local baseVersionWebR = "0.2.1"
 
 -- Define where WebR can be found
-local baseUrl = ""
+local baseUrl = "https://webr.r-wasm.org/v".. baseVersionWebR .."/"
 local serviceWorkerUrl = ""
 
 -- Define the webR communication protocol

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -17,6 +17,10 @@ format:
 - Added a visual spinning indicator to emphasize what code cell is currently running.
 - Improved status updates about installing R packages specified in the document's `package` key.
 
+## Bugfixes
+
+- Fixed `base-url` to allow for a localized version of `webR` away.
+
 ## Documentation
 
 - Added an [`examples/` directory](https://github.com/coatless/quarto-webr/tree/main/examples) containing examples for [HTML Documents](), [Books](), and [Websites](). ([#53](https://github.com/coatless/quarto-webr/issues/53))

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -19,7 +19,7 @@ format:
 
 ## Bugfixes
 
-- Fixed `base-url` to allow for a localized version of `webR` away.
+- Fixed `base-url` to allow for a localized version of `webR` away. ([#54](https://github.com/coatless/quarto-webr/issues/54))
 
 ## Documentation
 


### PR DESCRIPTION
Allow for the `base-url` option to be set away from the CDN.

Close #54 