### PR TITLE
Improve packages key installation

### DIFF
--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -143,20 +143,34 @@
   // Installing Packages
   if (showStartupMessage && setupRPackages) {
 
+    // Obtain a unique list of R packages
+    function checkUnique(value, index, array) {
+      return array.indexOf(value) === index;
+    }
+    var uniqueRPackageList = installRPackagesList.filter(checkUnique);
+
     // Determine number of packages to install
-    const nInstallPackages = installRPackagesList.length
+    const nInstallPackages = uniqueRPackageList.length
 
-    // Iterate through list of packages
-    for (let i = 0; i < nInstallPackages; i++) {
+    if (nInstallPackages == 1) {
+        // Update status of package installs
+        startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing package: ${uniqueRPackageList}</span>`;
 
-      // Retrieve the package
-      const activePackage = installRPackagesList[i];
+        // Install the package
+        await globalThis.webR.installPackages(uniqueRPackageList)
+    } else {
+      // Iterate through list of packages
+      for (let i = 0; i < nInstallPackages; i++) {
 
-      // Update status of package installs
-      startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing ${i + 1} of ${nInstallPackages} packages: ${activePackage}</span>`;
+        // Retrieve the package
+        const activePackage = uniqueRPackageList[i];
 
-      // Install the package
-      await globalThis.webR.installPackages(activePackage)
+        // Update status of package installs
+        startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing ${i + 1} of ${nInstallPackages} packages: ${activePackage}</span>`;
+
+        // Install the package
+        await globalThis.webR.installPackages([activePackage])
+      }
     }
 
   }

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -140,39 +140,30 @@
   // Setup a shelter
   globalThis.webRCodeShelter = await new globalThis.webR.Shelter();
 
-  // Installing Packages
-  if (showStartupMessage && setupRPackages) {
+  // Package install 
+  async function installRPackage(packages, verbose = true) {
 
-    // Obtain a unique list of R packages
-    function checkUnique(value, index, array) {
-      return array.indexOf(value) === index;
-    }
-    var uniqueRPackageList = installRPackagesList.filter(checkUnique);
+    // Iterate through package list
+    for (let i = 0; i < packages.length; i++) {
+      // Obtain one package
+      const activePackage = packages[i];
 
-    // Determine number of packages to install
-    const nInstallPackages = uniqueRPackageList.length
-
-    if (nInstallPackages == 1) {
-        // Update status of package installs
-        startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing package: ${uniqueRPackageList}</span>`;
-
-        // Install the package
-        await globalThis.webR.installPackages(uniqueRPackageList)
-    } else {
-      // Iterate through list of packages
-      for (let i = 0; i < nInstallPackages; i++) {
-
-        // Retrieve the package
-        const activePackage = uniqueRPackageList[i];
-
-        // Update status of package installs
-        startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing ${i + 1} of ${nInstallPackages} packages: ${activePackage}</span>`;
-
-        // Install the package
-        await globalThis.webR.installPackages([activePackage])
+      // Update status of package install with progress
+      if (verbose) {
+        startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
       }
-    }
 
+      // Install the selected package
+      await globalThis.webR.installPackages([activePackage]);
+    }
+  }
+
+  // Check to see if any packages need to be installed
+  if (setupRPackages) {
+    // Obtain only a unique list of packages
+    const uniqueRPackageList = Array.from(new Set(installRPackagesList));
+    // Install R packages one at a time (either silently or with a status update)
+    await installRPackage(uniqueRPackageList, showStartupMessage);
   }
 
   // Stop timer

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -141,16 +141,24 @@
   globalThis.webRCodeShelter = await new globalThis.webR.Shelter();
 
   // Package install 
-  async function installRPackage(packages, verbose = true) {
+  async function installRPackagesWithStatus(packages, status = true) {
+
+    // Update reason for code cells not being executable
+    document.querySelectorAll(".btn-webr").forEach((btn) => {
+      btn.innerText = "🟡 Installing packages ...";
+    });
 
     // Iterate through package list
     for (let i = 0; i < packages.length; i++) {
+
       // Obtain one package
       const activePackage = packages[i];
 
       // Update status of package install with progress
-      if (verbose) {
-        startupMessageWebR.innerHTML = `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> <span>Installing package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
+      if (status) {
+        startupMessageWebR.innerHTML = 
+           `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> 
+            <span>Installing package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
       }
 
       // Install the selected package
@@ -162,15 +170,16 @@
   if (setupRPackages) {
     // Obtain only a unique list of packages
     const uniqueRPackageList = Array.from(new Set(installRPackagesList));
+
     // Install R packages one at a time (either silently or with a status update)
-    await installRPackage(uniqueRPackageList, showStartupMessage);
+    await installRPackagesWithStatus(uniqueRPackageList, showStartupMessage);
   }
 
   // Stop timer
   const initializeWebRTimerEnd = performance.now();
 
+  // Release document status as ready
   if (showStartupMessage) {
-    // If initialized, switch to a green light
     startupMessageWebR.innerText = "🟢 Ready!"
   }
   

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -20,6 +20,7 @@ format:
 ## Bugfixes
 
 - Fixed `base-url` to allow for a localized version of `webR` away. ([#54](https://github.com/coatless/quarto-webr/issues/54))
+- Fixed document-level `packages` meta option not installing packages if the status bar was not present ([#69](https://github.com/coatless/quarto-webr/issues/69))
 
 ## Documentation
 


### PR DESCRIPTION
Re-factored package installation for the document key with an eye to re-using code for auto-detecting package installs inside of executed code cells.

Moreover, packages that are requested in the document header should no longer require the status header to be enabled to be installed prior to code cells becoming unlocked.

Close #68, Close #69