### PR TITLE
Support 'pager' events

### DIFF
--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -127,6 +127,41 @@
     // Create a canvas variable for graphics
     let canvas = undefined;
 
+    // Create a pager variable for help/file contents
+    let pager = [];
+
+    // Process 
+    async function parseTypePager(msg) { 
+
+        // Split out the event data
+        const { path, title, deleteFile } = msg.data; 
+
+        // Process the pager data by reading the information from disk
+        const paged_data = await globalThis.webR.FS.readFile(path).then((data) => {
+          // Obtain the file content
+          let content = new TextDecoder().decode(data);
+
+          // Remove excessive backspace characters until none remain
+          while(content.match(/.[\b]/)){
+            content = content.replace(/.[\b]/g, '');
+          }
+
+          // Returned cleaned data
+          return content;
+        });
+
+        // Is it set to delete?
+        console.log(deleteFile)
+
+        // Unlink file if needed
+        if (deleteFile) { 
+          globalThis.webR.FS.unlink(path); 
+        } 
+
+        // Return extracted data with spaces
+        return paged_data;
+    } 
+
     // Initialize webR
     await globalThis.webR.init();
 
@@ -155,8 +190,8 @@
       // Clean the state
       const msgs = await webR.flush();
 
-      // Output each image stored
-      msgs.forEach(msg => {
+      // Output each image event stored
+      msgs.forEach((msg) => {
         // Determine if old canvas can be used or a new canvas is required.
         if (msg.type === 'canvas'){
           // Add image to the current canvas
@@ -171,8 +206,17 @@
             canvas.style.display = "block";
             canvas.style.margin = "auto";
           }
-        }
+        } 
       });
+
+      // Use `map` to process the filtered "pager" events asynchronously
+      const pager = await Promise.all(
+        msgs.filter(msg => msg.type === 'pager').map(
+          async (msg) => {
+            return await parseTypePager(msg);
+          }
+        )
+      );
 
       // Nullify the outputDiv of content
       outputDiv.innerHTML = "";
@@ -195,6 +239,18 @@
         const p = document.createElement("p");
         p.appendChild(canvas);
         outputDiv.appendChild(p);
+      }
+
+      // Display the pager data
+      if (pager) {
+        // Use the `pre` element to preserve whitespace.
+        pager.forEach((paged_data, index) => {
+          let pre_pager = document.createElement("pre");
+          pre_pager.innerText = paged_data;
+          pre_pager.classList.add("qwebr-output-type-pager");
+          pre_pager.setAttribute("id", "qwebr-output-type-pager-" + (index + 1));
+          outputDiv.appendChild(pre_pager);
+        });
       }
     } finally {
       // Clean up the remaining code

--- a/_extensions/webr/webr-context-output.html
+++ b/_extensions/webr/webr-context-output.html
@@ -10,6 +10,41 @@
     // Create a canvas variable for graphics
     let canvas = undefined;
 
+    // Create a pager variable for help/file contents
+    let pager = [];
+
+    // Process 
+    async function parseTypePager(msg) { 
+
+        // Split out the event data
+        const { path, title, deleteFile } = msg.data; 
+
+        // Process the pager data by reading the information from disk
+        const paged_data = await globalThis.webR.FS.readFile(path).then((data) => {
+          // Obtain the file content
+          let content = new TextDecoder().decode(data);
+
+          // Remove excessive backspace characters until none remain
+          while(content.match(/.[\b]/)){
+            content = content.replace(/.[\b]/g, '');
+          }
+
+          // Returned cleaned data
+          return content;
+        });
+
+        // Is it set to delete?
+        console.log(deleteFile)
+
+        // Unlink file if needed
+        if (deleteFile) { 
+          globalThis.webR.FS.unlink(path); 
+        } 
+
+        // Return extracted data with spaces
+        return paged_data;
+    } 
+
     // Initialize webR
     await globalThis.webR.init();
 
@@ -55,7 +90,16 @@
             canvas.style.margin = "auto";
           }
         }
-      });
+      });      
+      
+      // Use `map` to process the filtered "pager" events asynchronously
+      const pager = await Promise.all(
+        msgs.filter(msg => msg.type === 'pager').map(
+          async (msg) => {
+            return await parseTypePager(msg);
+          }
+        )
+      );
 
       // Nullify the outputDiv of content
       outputDiv.innerHTML = "";
@@ -78,6 +122,18 @@
         const p = document.createElement("p");
         p.appendChild(canvas);
         outputDiv.appendChild(p);
+      }
+
+      // Display the pager data
+      if (pager) {
+        // Use the `pre` element to preserve whitespace.
+        pager.forEach((paged_data) => {
+          let pre_pager = document.createElement("pre");
+          pre_pager.innerText = paged_data;
+          pre_pager.classList.add("qwebr-output-type-pager");
+          pre_pager.setAttribute("id", "qwebr-output-type-pager-" + (index + 1));
+          outputDiv.appendChild(pre_pager);
+        });
       }
     } finally {
       // Clean up the remaining code

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -140,6 +140,9 @@
   // Setup a shelter
   globalThis.webRCodeShelter = await new globalThis.webR.Shelter();
 
+  // Setup a pager to allow processing help documentation 
+  await globalThis.webR.evalRVoid('webr::pager_install()'); 
+
   // Package install 
   async function installRPackagesWithStatus(packages, status = true) {
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -14,8 +14,10 @@ format:
 
 - Added a Global Interpreter Lock (GIL) to ensures that only one code cell runs at a time, preventing simultaneous execution conflicts.
   - With this enhancement, you can now enjoy smoother and more predictable execution of your code, without interference from concurrently running code cells.
-- Added a visual spinning indicator to emphasize what code cell is currently running.
-- Improved status updates about installing R packages specified in the document's `package` key.
+- Added a visual spinning indicator to emphasize what code cell is currently running. ([#64](https://github.com/coatless/quarto-webr/issues/64))
+- Improved status updates about installing R packages specified in the document's `package` key. ([#68](https://github.com/coatless/quarto-webr/issues/68))
+- Fully supported `pager` event types. ([#58](https://github.com/coatless/quarto-webr/issues/58))
+  - With this update, looking at R help documentation for a function is now possible.
 
 ## Bugfixes
 


### PR DESCRIPTION
In this PR, we enable support for pager values. 

Pager support allows for R actions that previously attempted to start an external pager binary using the `system()` function. The biggest culprit was the R help documentation, e.g. `?mean` or `help(mean)` yielding an error like:

```r
Warning in file.show(temp, title = gettextf("R Help on %s", sQuote(topic)),  :
  system call failed: Function not implemented
Warning: error in running command
```

Close #58 