### PR TITLE
Fix service worker check

### DIFF
--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -105,7 +105,7 @@ function setWebRInitializationOptions(meta)
   -- https://docs.r-wasm.org/webr/latest/api/js/interfaces/WebR.WebROptions.html#channeltype
   if not is_variable_empty(webr["channel-type"]) then
     channelType = convertMetaChannelTypeToWebROption(pandoc.utils.stringify(webr["channel-type"]))
-    if not (channelType == "ChannelType.Automatic" and channelType == "ChannelType.ServiceWorker") then
+    if not (channelType == "ChannelType.Automatic" or channelType == "ChannelType.ServiceWorker") then
       hasServiceWorkerFiles = false
     end
   end

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -23,12 +23,18 @@ format:
 
 - Fixed `base-url` to allow for a localized version of `webR` away. ([#54](https://github.com/coatless/quarto-webr/issues/54))
 - Fixed document-level `packages` meta option not installing packages if the status bar was not present ([#69](https://github.com/coatless/quarto-webr/issues/69))
+- Fixed service workers not being placed if user explicitly set `channel-type: 'automatic'` ([#74](https://github.com/coatless/quarto-webr/pull/74))
 
 ## Documentation
 
 - Added an [`examples/` directory](https://github.com/coatless/quarto-webr/tree/main/docs/examples) containing examples for [HTML Documents](https://github.com/coatless/quarto-webr/tree/main/docs/examples/html-document), [Books](https://github.com/coatless/quarto-webr/tree/main/docs/examples/book), and [Websites](https://github.com/coatless/quarto-webr/tree/main/docs/examples/websites). ([#53](https://github.com/coatless/quarto-webr/issues/53))
 - Added a documentation page that contains the extension updates and release dates. 
 - Added an FAQ page covering questions from posit::conf(2023). ([#56](https://github.com/coatless/quarto-webr/issues/56))
+
+## Deployment
+
+- Switched from Quarto's publishing action to individually rendering projects, merging output, and, then, publishing. ([#73](https://github.com/coatless/quarto-webr/pull/73))
+  - By using a custom publish action, we can retain a single repository with nested quarto projects (e.g. A website project that also contains a book.)
 
 # 0.3.6: Ready, Set, Run. (09-24-2023)
 


### PR DESCRIPTION
If `automatic` is user-specified, we weren't correctly ensuring the worker files would be deployed.