### PR TITLE
Autoload packages

### DIFF
--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -58,6 +58,7 @@
   var installRPackagesList = [{{INSTALLRPACKAGESLIST}}];
   // Check to see if we have an empty array, if we do set to skip the installation.
   var setupRPackages = !(installRPackagesList.indexOf("") !== -1);
+  var autoloadRPackages = {{AUTOLOADRPACKAGES}};
 
   // Display a startup message?
   var showStartupMessage = {{SHOWSTARTUPMESSAGE}};
@@ -157,7 +158,7 @@
       <i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i>
       <span>${message}</span>`;
   }
-  
+
   // Function to install a single package
   async function qwebrInstallRPackage(packageName) {
     await globalThis.webR.installPackages([packageName]);
@@ -209,8 +210,10 @@
     // Install R packages one at a time (either silently or with a status update)
     await qwebrProcessRPackagesWithStatus(uniqueRPackageList, 'install', showStartupMessage);
 
-    // Load R packages one at a time (either silently or with a status update)
-    await qwebrProcessRPackagesWithStatus(uniqueRPackageList, 'load', showStartupMessage);
+    if(autoloadRPackages) {
+      // Load R packages one at a time (either silently or with a status update)
+      await qwebrProcessRPackagesWithStatus(uniqueRPackageList, 'load', showStartupMessage);
+    }
   }
 
   // Stop timer

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -143,39 +143,63 @@
   // Setup a pager to allow processing help documentation 
   await globalThis.webR.evalRVoid('webr::pager_install()'); 
 
-  async function processRPackagesWithStatus(packages, processType, status = true) {
-    // Set the message prefix based on the process type
+  // Function to set the button text
+  function qwebrSetInteractiveButtonState(buttonText, enableCodeButton = true) {
+    document.querySelectorAll(".btn-webr").forEach((btn) => {
+      btn.innerHTML = buttonText;
+      btn.disabled = !enableCodeButton;
+    });
+  }
+
+  // Function to update the status message
+  function qwebrUpdateStatusHeader(message) {
+    startupMessageWebR.innerHTML = `
+      <i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i>
+      <span>${message}</span>`;
+  }
+  
+  // Function to install a single package
+  async function qwebrInstallRPackage(packageName) {
+    await globalThis.webR.installPackages([packageName]);
+  }
+
+  // Function to load a single package
+  async function qwebrLoadRPackage(packageName) {
+    await globalThis.webR.evalRVoid(`library(${packageName});`);
+  }
+
+  // Generic function to process R packages
+  async function qwebrProcessRPackagesWithStatus(packages, processType, displayStatusMessageUpdate = true) {
+    // Switch between contexts
     const messagePrefix = processType === 'install' ? 'Installing' : 'Loading';
 
-    // Update reason for code cells not being executable
-    document.querySelectorAll(".btn-webr").forEach((btn) => {
-      btn.innerText = `🟡 ${messagePrefix} packages ...`;
-    });
+    // Modify button state
+    qwebrSetInteractiveButtonState(`🟡 ${messagePrefix} package ...`, false);
 
-    // Iterate through the package list
+    // Iterate over packages
     for (let i = 0; i < packages.length; i++) {
       const activePackage = packages[i];
-
-      // Update status of the package process with progress
-      if (status) {
-        startupMessageWebR.innerHTML = `
-          <i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i>
-          <span>${messagePrefix} package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
+      const formattedMessage = `${messagePrefix} package ${i + 1} out of ${packages.length}: ${activePackage}`;
+      
+      // Display the update
+      if (displayStatusMessageUpdate) {
+        qwebrUpdateStatusHeader(formattedMessage);
       }
 
-      // Perform the appropriate action (install or load) for the selected package
+      // Run package installation
       if (processType === 'install') {
-        await globalThis.webR.installPackages([activePackage]);
+        await qwebrInstallRPackage(activePackage);
       } else {
-        await globalThis.webR.evalRVoid(`library(${activePackage});`);
+        await qwebrLoadRPackage(activePackage);
       }
     }
 
-    // Flush away state if loading packages
+    // Clean slate
     if (processType === 'load') {
       await globalThis.webR.flush();
     }
   }
+
 
   // Check to see if any packages need to be installed
   if (setupRPackages) {
@@ -183,10 +207,10 @@
     const uniqueRPackageList = Array.from(new Set(installRPackagesList));
 
     // Install R packages one at a time (either silently or with a status update)
-    await processRPackagesWithStatus(uniqueRPackageList, 'install', showStartupMessage);
+    await qwebrProcessRPackagesWithStatus(uniqueRPackageList, 'install', showStartupMessage);
 
     // Load R packages one at a time (either silently or with a status update)
-    await processRPackagesWithStatus(uniqueRPackageList, 'load', showStartupMessage);
+    await qwebrProcessRPackagesWithStatus(uniqueRPackageList, 'load', showStartupMessage);
   }
 
   // Stop timer
@@ -197,10 +221,9 @@
     startupMessageWebR.innerText = "🟢 Ready!"
   }
   
-  // Switch to allowing code to be executed
-  document.querySelectorAll(".btn-webr").forEach((btn) => {
-    btn.innerHTML = '<i class="fa-solid fa-play qwebr-icon-run-code"></i> <span>Run Code</span>';
-    btn.disabled = false;
-  });
+  qwebrSetInteractiveButtonState(
+    `<i class="fa-solid fa-play qwebr-icon-run-code"></i> <span>Run Code</span>`, 
+    true
+  );
 
 </script>

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -143,61 +143,39 @@
   // Setup a pager to allow processing help documentation 
   await globalThis.webR.evalRVoid('webr::pager_install()'); 
 
-  // Package install 
-  async function installRPackagesWithStatus(packages, status = true) {
+  async function processRPackagesWithStatus(packages, processType, status = true) {
+    // Set the message prefix based on the process type
+    const messagePrefix = processType === 'install' ? 'Installing' : 'Loading';
 
     // Update reason for code cells not being executable
     document.querySelectorAll(".btn-webr").forEach((btn) => {
-      btn.innerText = "🟡 Installing packages ...";
+      btn.innerText = `🟡 ${messagePrefix} packages ...`;
     });
 
-    // Iterate through package list
+    // Iterate through the package list
     for (let i = 0; i < packages.length; i++) {
-
-      // Obtain one package
       const activePackage = packages[i];
 
-      // Update status of package install with progress
+      // Update status of the package process with progress
       if (status) {
-        startupMessageWebR.innerHTML = 
-           `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> 
-            <span>Installing package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
+        startupMessageWebR.innerHTML = `
+          <i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i>
+          <span>${messagePrefix} package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
       }
 
-      // Install the selected package
-      await globalThis.webR.installPackages([activePackage]);
-    }
-  }
-
-  // Package autoload
-  async function loadRPackagesWithStatus(packages, status = true) {
-
-    // Update reason for code cells not being executable
-    document.querySelectorAll(".btn-webr").forEach((btn) => {
-      btn.innerText = "🟡 Loading packages ...";
-    });
-
-    // Iterate through package list
-    for (let i = 0; i < packages.length; i++) {
-
-      // Obtain one package
-      const activePackage = packages[i];
-
-      // Update status of package load with progress
-      if (status) {
-        startupMessageWebR.innerHTML = 
-          `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> 
-            <span>Loading package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
+      // Perform the appropriate action (install or load) for the selected package
+      if (processType === 'install') {
+        await globalThis.webR.installPackages([activePackage]);
+      } else {
+        await globalThis.webR.evalRVoid(`library(${activePackage});`);
       }
-
-      // Load the selected package
-      await globalThis.webR.evalRVoid("library(" + activePackage + ");");
     }
 
-    // Flush away state
-    await globalThis.webR.flush()
+    // Flush away state if loading packages
+    if (processType === 'load') {
+      await globalThis.webR.flush();
+    }
   }
-
 
   // Check to see if any packages need to be installed
   if (setupRPackages) {
@@ -205,10 +183,10 @@
     const uniqueRPackageList = Array.from(new Set(installRPackagesList));
 
     // Install R packages one at a time (either silently or with a status update)
-    await installRPackagesWithStatus(uniqueRPackageList, showStartupMessage);
+    await processRPackagesWithStatus(uniqueRPackageList, 'install', showStartupMessage);
 
     // Load R packages one at a time (either silently or with a status update)
-    await loadRPackagesWithStatus(uniqueRPackageList, showStartupMessage);
+    await processRPackagesWithStatus(uniqueRPackageList, 'load', showStartupMessage);
   }
 
   // Stop timer

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -169,6 +169,36 @@
     }
   }
 
+  // Package autoload
+  async function loadRPackagesWithStatus(packages, status = true) {
+
+    // Update reason for code cells not being executable
+    document.querySelectorAll(".btn-webr").forEach((btn) => {
+      btn.innerText = "🟡 Loading packages ...";
+    });
+
+    // Iterate through package list
+    for (let i = 0; i < packages.length; i++) {
+
+      // Obtain one package
+      const activePackage = packages[i];
+
+      // Update status of package load with progress
+      if (status) {
+        startupMessageWebR.innerHTML = 
+          `<i class="fa-solid fa-spinner fa-spin qwebr-icon-status-spinner"></i> 
+            <span>Loading package ${i + 1} out of ${packages.length}: ${activePackage}</span>`;
+      }
+
+      // Load the selected package
+      await globalThis.webR.evalRVoid("library(" + activePackage + ");");
+    }
+
+    // Flush away state
+    await globalThis.webR.flush()
+  }
+
+
   // Check to see if any packages need to be installed
   if (setupRPackages) {
     // Obtain only a unique list of packages
@@ -176,6 +206,9 @@
 
     // Install R packages one at a time (either silently or with a status update)
     await installRPackagesWithStatus(uniqueRPackageList, showStartupMessage);
+
+    // Load R packages one at a time (either silently or with a status update)
+    await loadRPackagesWithStatus(uniqueRPackageList, showStartupMessage);
   }
 
   // Stop timer

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -33,6 +33,9 @@ local showHeaderMessage = "false"
 
 -- Define an empty string if no packages need to be installed.
 local installRPackagesList = "''"
+
+-- Define whether R packages should automatically be loaded
+local autoloadRPackages = "true"
 ----
 
 --- Setup variables for tracking number of code cells
@@ -150,6 +153,11 @@ function setWebRInitializationOptions(meta)
     end
 
     installRPackagesList = table.concat(package_list, ", ")
+
+    if not is_variable_empty(webr['autoload-packages']) then
+      autoloadRPackages = pandoc.utils.stringify(webr["autoload-packages"])
+    end
+
   end
 
   
@@ -292,7 +300,8 @@ function initializationWebR()
     ["CHANNELTYPE"] = channelType,
     ["SERVICEWORKERURL"] = serviceWorkerUrl, 
     ["HOMEDIR"] = homeDir,
-    ["INSTALLRPACKAGESLIST"] = installRPackagesList
+    ["INSTALLRPACKAGESLIST"] = installRPackagesList,
+    ["AUTOLOADRPACKAGES"] = autoloadRPackages
     -- ["VERSION"] = baseVersionWebR
   }
   

--- a/docs/qwebr-meta-options.qmd
+++ b/docs/qwebr-meta-options.qmd
@@ -87,3 +87,8 @@ The extension also provides native options that affect its behavior:
 
 - **Description**: Specifies R packages to install automatically when the document opens.
 - **Default Value**: `[]`
+
+### `autoload-packages`
+
+- **Description**: The `autoload-packages` option allows you to control whether R packages specified in the `packages` document option will be automatically loaded using `library()` calls when the document opens. By default, this option is set to `true`, meaning that packages listed in the `packages` option will be automatically loaded. If you set it to `false`, you will need to include a code cell with `library(package)` function calls for each package in `packages`.
+- **Default Value**: `true`

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -12,6 +12,9 @@ format:
 
 ## Features
 
+- Added `autoload-packages` document meta option key that will automatically load packages specified in the `packages` key. The default value is `true`. ([#75](https://github.com/coatless/quarto-webr/issues/75))
+  - This feature simplifies the use of packages, eliminating the need to call `library()` in interactive code cells or setup code cells, as the specified packages will be loaded automatically. 
+
 ## Bugfixes
 
 ## Documentation
@@ -21,7 +24,7 @@ format:
 
 ## Deployment
 
-- Added a `tests/` directory that contains Quarto documents used across multiple browsers before triggering a point release. ([#74](https://github.com/coatless/quarto-webr/issues/74))
+- Added a `tests/` directory that contains Quarto documents used across multiple browsers before triggering a point release. ([#76](https://github.com/coatless/quarto-webr/issues/76))
 
 # 0.3.7: Mutex On, Mutex Off (10-16-2023)
 

--- a/docs/qwebr-using-r-packages.qmd
+++ b/docs/qwebr-using-r-packages.qmd
@@ -49,7 +49,17 @@ webr:
 ---
 ```
 
-By using this approach, you ensure that necessary packages are available right from the start when readers access your document. Moreover, the webR code cells do not become active until the packages are installed. This can be especially helpful when working with packages in multiple cells.
+By using this approach, you ensure that necessary packages are available right from the start when readers access your document. Moreover, the webR code cells will not become active until the packages are installed and loaded. This can be especially helpful when working with packages in multiple cells.
+
+If you do not want the packages to be loaded by default, add the `autoload-packages: false` under `webr` in the YAML header. This will disable the calls to load each R package in the `packages` key, e.g. `library(package)`.
+
+```yaml
+---
+webr:
+  packages: ['ggplot2', 'dplyr']
+  autoload-packages: false
+---
+```
 
 # Installing an R Package Interactively
 
@@ -66,3 +76,20 @@ webr::install("ggplot2")
 ```
 
 Using this approach, you can install packages on a per-code cell basis, which can be more efficient when you only need specific packages for certain parts of your document.
+
+
+# Load R Packages Interactively
+
+Once an R package is installed, you can use it just like normal by calling either `library()` or `require()` to load the package. 
+
+For instance, if you have installed `ggplot2` in the prior code cell, then the following will load the `ggplot2` and create a scatterplot.
+
+```{webr-r}
+library("ggplot2")
+
+ggplot(mpg, aes(displ, hwy, colour = class)) + 
+  geom_point()
+```
+
+
+Not a fan of having a code cell dedicated to load packages? You can use the `packages` key option above to let the `quarto-webr` extension take care of loading the packages after installing. 

--- a/tests/qwebr-test-packages-autoload.qmd
+++ b/tests/qwebr-test-packages-autoload.qmd
@@ -1,0 +1,17 @@
+---
+title: "Test: Autoload Package"
+format: html
+engine: knitr
+webr:
+  packages: ['ggplot2']
+  autoload-packages: 'false'
+filters:
+  - webr
+---
+
+This webpage tests the `autoload-packages` key meta option by not loading the requested packages.
+
+```{webr-r}
+# Must call the library statement
+library('ggplot2')
+```

--- a/tests/qwebr-test-packages-multi.qmd
+++ b/tests/qwebr-test-packages-multi.qmd
@@ -1,15 +1,16 @@
 ---
-title: "Test: Package Keys"
+title: "Test: Packages Key with Autoloading"
 format: html
 engine: knitr
 webr:
   packages: ['ggplot2', 'dplyr']
+  autoload-packages: true
 filters:
   - webr
 ---
 
-This webpage tests the `packages` key meta option.
+This webpage tests the `packages` key meta option with the default of `autoload-packages` removing the need for a `library()` call.
 
 ```{webr-r}
-library('ggplot2')
+ggplot()
 ```


### PR DESCRIPTION
In this PR, we add an `autoload-packages` key to control whether packages specified in the document header should be loaded after being installed. 

That is, we now have:

```yaml
webr:
  packages: ['ggplot2', 'dplyr']
```

Translating to: 

```r
install.packages(packages)
```

And 

```yaml
webr:
  autoload-packages: true
```

Translating to:

```r
for(pkg in packages) {
  library(pkg, character.only = TRUE)
}
```

If the `packages` key is empty, then we do not attempt to load any packages.

Close #75 