### PR TITLE
Differentiate Output Events and Add CSS Styling Classes

### DIFF
--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -1,14 +1,19 @@
-<button class="btn btn-default btn-webr" disabled type="button" id="webr-run-button-{{WEBRCOUNTER}}">🟡 Loading
+<button class="btn btn-default btn-qwebr" disabled type="button" id="qwebr-run-button-{{WEBRCOUNTER}}">🟡 Loading
   webR...</button>
-<div id="webr-editor-{{WEBRCOUNTER}}"></div>
-<div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
-  <pre style="visibility: hidden"></pre>
+<div id="qwebr-interactive-area-{{WEBRCOUNTER}}">
+  <div id="qwebr-editor-{{WEBRCOUNTER}}"></div>
+  <div id="qwebr-output-code-area-{{WEBRCOUNTER}}" aria-live="assertive">
+    <pre style="visibility: hidden"></pre>
+  </div>
+</div>
+<div id="qwebr-output-graph-area-{{WEBRCOUNTER}}">
 </div>
 <script type="module">
   // Retrieve webR code cell information
-  const runButton = document.getElementById("webr-run-button-{{WEBRCOUNTER}}");
-  const outputDiv = document.getElementById("webr-code-output-{{WEBRCOUNTER}}");
-  const editorDiv = document.getElementById("webr-editor-{{WEBRCOUNTER}}");
+  const runButton = document.getElementById("qwebr-run-button-{{WEBRCOUNTER}}");
+  const outputCodeDiv = document.getElementById("qwebr-output-code-area-{{WEBRCOUNTER}}");
+  const editorDiv = document.getElementById("qwebr-editor-{{WEBRCOUNTER}}");
+  const outputGraphDiv = document.getElementById("qwebr-output-graph-area-{{WEBRCOUNTER}}");
 
   // Add a light grey outline around the code editor
   editorDiv.style.border = "1px solid #eee";
@@ -117,7 +122,7 @@
   async function executeCode(codeToRun) {
 
     // Disallowing execution of other code cells
-    document.querySelectorAll(".btn-webr").forEach((btn) => {
+    document.querySelectorAll(".btn-qwebr").forEach((btn) => {
       btn.disabled = true;
     });
 
@@ -137,7 +142,7 @@
         const { path, title, deleteFile } = msg.data; 
 
         // Process the pager data by reading the information from disk
-        const paged_data = await globalThis.webR.FS.readFile(path).then((data) => {
+        const paged_data = await webR.FS.readFile(path).then((data) => {
           // Obtain the file content
           let content = new TextDecoder().decode(data);
 
@@ -152,7 +157,7 @@
 
         // Unlink file if needed
         if (deleteFile) { 
-          globalThis.webR.FS.unlink(path); 
+          await webR.FS.unlink(path); 
         } 
 
         // Return extracted data with spaces
@@ -160,7 +165,7 @@
     } 
 
     // Initialize webR
-    await globalThis.webR.init();
+    await webR.init();
 
     // Setup a webR canvas by making a namespace call into the {webr} package
     await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
@@ -180,9 +185,14 @@
       await webR.evalRVoid("dev.off()");
 
       // Merge output streams of STDOUT and STDErr (messages and errors are combined.)
-      const out = result.output.filter(
-        evt => evt.type == "stdout" || evt.type == "stderr"
-      ).map((evt) => evt.data).join("\n");
+      const out = result.output
+        .filter(evt => evt.type === "stdout" || evt.type === "stderr")
+        .map((evt, index) => {
+          const className = `qwebr-output-code-${evt.type}`;
+          return `<code id="${className}-editor-{{WEBRCOUNTER}}-result-${index + 1}" class="${className}">${evt.data}</code>`;
+        })
+        .join("\n");
+
 
       // Clean the state
       const msgs = await webR.flush();
@@ -215,27 +225,26 @@
         )
       );
 
-      // Nullify the outputDiv of content
-      outputDiv.innerHTML = "";
+      // Nullify the output area of content
+      outputCodeDiv.innerHTML = "";
+      outputGraphDiv.innerHTML = "";
 
       // Design an output object for messages
       const pre = document.createElement("pre");
       if (/\S/.test(out)) {
-        // Display results as text
-        const code = document.createElement("code");
-        code.innerText = out;
-        pre.appendChild(code);
+        // Display results as HTML elements to retain output styling
+        const div = document.createElement("div");
+        div.innerHTML = out;
+        pre.appendChild(div);
       } else {
         // If nothing is present, hide the element.
         pre.style.visibility = "hidden";
       }
-      outputDiv.appendChild(pre);
+      outputCodeDiv.appendChild(pre);
 
       // Place the graphics on the canvas
       if (canvas) {
-        const p = document.createElement("p");
-        p.appendChild(canvas);
-        outputDiv.appendChild(p);
+        outputGraphDiv.appendChild(canvas);
       }
 
       // Display the pager data
@@ -244,9 +253,9 @@
         pager.forEach((paged_data, index) => {
           let pre_pager = document.createElement("pre");
           pre_pager.innerText = paged_data;
-          pre_pager.classList.add("qwebr-output-type-pager");
-          pre_pager.setAttribute("id", "qwebr-output-type-pager-{{WEBRCOUNTER}}-" + (index + 1));
-          outputDiv.appendChild(pre_pager);
+          pre_pager.classList.add("qwebr-output-code-pager");
+          pre_pager.setAttribute("id", "qwebr-output-code-pager-editor-{{WEBRCOUNTER}}-result-" + (index + 1));
+          outputCodeDiv.appendChild(pre_pager);
         });
       }
     } finally {
@@ -255,7 +264,7 @@
     }
 
     // Switch to allowing execution of code
-    document.querySelectorAll(".btn-webr").forEach((btn) => {
+    document.querySelectorAll(".btn-qwebr").forEach((btn) => {
       btn.disabled = false;
     });
 

--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -1,16 +1,16 @@
-<button class="btn btn-default btn-qwebr" disabled type="button" id="qwebr-run-button-{{WEBRCOUNTER}}">🟡 Loading
+<button class="btn btn-default qwebr-button-run" disabled type="button" id="qwebr-button-run-{{WEBRCOUNTER}}">🟡 Loading
   webR...</button>
-<div id="qwebr-interactive-area-{{WEBRCOUNTER}}">
-  <div id="qwebr-editor-{{WEBRCOUNTER}}"></div>
-  <div id="qwebr-output-code-area-{{WEBRCOUNTER}}" aria-live="assertive">
+<div id="qwebr-interactive-area-{{WEBRCOUNTER}}" class="qwebr-interactive-area">
+  <div id="qwebr-editor-{{WEBRCOUNTER}}" class="qwebr-editor"></div>
+  <div id="qwebr-output-code-area-{{WEBRCOUNTER}}" class="qwebr-output-code-area" aria-live="assertive">
     <pre style="visibility: hidden"></pre>
   </div>
 </div>
-<div id="qwebr-output-graph-area-{{WEBRCOUNTER}}">
+<div id="qwebr-output-graph-area-{{WEBRCOUNTER}}" class="qwebr-output-graph-area">
 </div>
 <script type="module">
   // Retrieve webR code cell information
-  const runButton = document.getElementById("qwebr-run-button-{{WEBRCOUNTER}}");
+  const runButton = document.getElementById("qwebr-button-run-{{WEBRCOUNTER}}");
   const outputCodeDiv = document.getElementById("qwebr-output-code-area-{{WEBRCOUNTER}}");
   const editorDiv = document.getElementById("qwebr-editor-{{WEBRCOUNTER}}");
   const outputGraphDiv = document.getElementById("qwebr-output-graph-area-{{WEBRCOUNTER}}");
@@ -122,7 +122,7 @@
   async function executeCode(codeToRun) {
 
     // Disallowing execution of other code cells
-    document.querySelectorAll(".btn-qwebr").forEach((btn) => {
+    document.querySelectorAll(".qwebr-button-run").forEach((btn) => {
       btn.disabled = true;
     });
 
@@ -264,7 +264,7 @@
     }
 
     // Switch to allowing execution of code
-    document.querySelectorAll(".btn-qwebr").forEach((btn) => {
+    document.querySelectorAll(".qwebr-button-run").forEach((btn) => {
       btn.disabled = false;
     });
 

--- a/_extensions/webr/webr-context-output.html
+++ b/_extensions/webr/webr-context-output.html
@@ -1,9 +1,9 @@
-<div id="qwebr-noninteractive-area-{{WEBRCOUNTER}}">
-  <div id="qwebr-output-code-area-{{WEBRCOUNTER}}" aria-live="assertive">
+<div id="qwebr-noninteractive-area-{{WEBRCOUNTER}}" class="qwebr-noninteractive-area">
+  <div id="qwebr-output-code-area-{{WEBRCOUNTER}}" class="qwebr-output-code-area" aria-live="assertive">
     <pre style="visibility: hidden"></pre>
   </div>
 </div>
-<div id="qwebr-output-graph-area-{{WEBRCOUNTER}}">
+<div id="qwebr-output-graph-area-{{WEBRCOUNTER}}" class="qwebr-output-graph-area">
 </div>
 <script type="module">
   // Retrieve webR code cell information

--- a/_extensions/webr/webr-context-output.html
+++ b/_extensions/webr/webr-context-output.html
@@ -1,9 +1,14 @@
-<div id="webr-code-output-{{WEBRCOUNTER}}" aria-live="assertive">
-  <pre style="visibility: hidden"></pre>
+<div id="qwebr-noninteractive-area-{{WEBRCOUNTER}}">
+  <div id="qwebr-output-code-area-{{WEBRCOUNTER}}" aria-live="assertive">
+    <pre style="visibility: hidden"></pre>
+  </div>
+</div>
+<div id="qwebr-output-graph-area-{{WEBRCOUNTER}}">
 </div>
 <script type="module">
   // Retrieve webR code cell information
-  const outputDiv = document.getElementById("webr-code-output-{{WEBRCOUNTER}}");
+  const outputCodeDiv = document.getElementById("qwebr-output-code-area-{{WEBRCOUNTER}}");
+  const outputGraphDiv = document.getElementById("qwebr-output-graph-area-{{WEBRCOUNTER}}");
   
   // Function to execute the code (accepts code as an argument)
   async function executeOutputOnlyCode(codeToRun) {  
@@ -20,7 +25,7 @@
         const { path, title, deleteFile } = msg.data; 
 
         // Process the pager data by reading the information from disk
-        const paged_data = await globalThis.webR.FS.readFile(path).then((data) => {
+        const paged_data = await webR.FS.readFile(path).then((data) => {
           // Obtain the file content
           let content = new TextDecoder().decode(data);
 
@@ -35,7 +40,7 @@
 
         // Unlink file if needed
         if (deleteFile) { 
-          globalThis.webR.FS.unlink(path); 
+          await webR.FS.unlink(path); 
         } 
 
         // Return extracted data with spaces
@@ -43,7 +48,7 @@
     } 
 
     // Initialize webR
-    await globalThis.webR.init();
+    await webR.init();
 
     // Setup a webR canvas by making a namespace call into the {webr} package
     await webR.evalRVoid("webr::canvas(width={{WIDTH}}, height={{HEIGHT}})");
@@ -63,9 +68,13 @@
       await webR.evalRVoid("dev.off()");
 
       // Merge output streams of STDOUT and STDErr (messages and errors are combined.)
-      const out = result.output.filter(
-        evt => evt.type == "stdout" || evt.type == "stderr"
-      ).map((evt) => evt.data).join("\n");
+      const out = result.output
+        .filter(evt => evt.type === "stdout" || evt.type === "stderr")
+        .map((evt, index) => {
+          const className = `qwebr-output-code-${evt.type}`;
+          return `<code id="${className}-editor-{{WEBRCOUNTER}}-result-${index + 1}" class="${className}">${evt.data}</code>`;
+        })
+        .join("\n");
 
       // Clean the state
       const msgs = await webR.flush();
@@ -98,27 +107,26 @@
         )
       );
 
-      // Nullify the outputDiv of content
-      outputDiv.innerHTML = "";
+      // Nullify the output area of content
+      outputCodeDiv.innerHTML = "";
+      outputGraphDiv.innerHTML = "";
 
       // Design an output object for messages
       const pre = document.createElement("pre");
       if (/\S/.test(out)) {
-        // Display results as text
-        const code = document.createElement("code");
-        code.innerText = out;
-        pre.appendChild(code);
+        // Display results as HTML elements to retain output styling
+        const div = document.createElement("div");
+        div.innerHTML = out;
+        pre.appendChild(div);
       } else {
         // If nothing is present, hide the element.
         pre.style.visibility = "hidden";
       }
-      outputDiv.appendChild(pre);
+      outputCodeDiv.appendChild(pre);
 
       // Place the graphics on the canvas
       if (canvas) {
-        const p = document.createElement("p");
-        p.appendChild(canvas);
-        outputDiv.appendChild(p);
+        outputGraphDiv.appendChild(canvas);
       }
 
       // Display the pager data
@@ -127,9 +135,9 @@
         pager.forEach((paged_data, index) => {
           let pre_pager = document.createElement("pre");
           pre_pager.innerText = paged_data;
-          pre_pager.classList.add("qwebr-output-type-pager");
-          pre_pager.setAttribute("id", "qwebr-output-type-pager-{{WEBRCOUNTER}}-" + (index + 1));
-          outputDiv.appendChild(pre_pager);
+          pre_pager.classList.add("qwebr-output-code-pager");
+          pre_pager.setAttribute("id", "qwebr-output-code-pager-editor-{{WEBRCOUNTER}}-result-" + (index + 1));
+          outputCodeDiv.appendChild(pre_pager);
         });
       }
     } finally {
@@ -139,5 +147,5 @@
   }
 
   // Run the code
-  executeOutputOnlyCode(`{{WEBRCODE}}`)
+  await executeOutputOnlyCode(`{{WEBRCODE}}`)
 </script>

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -13,7 +13,15 @@
     color: #0d9c29
   }
 
-  .btn-webr {
+  .qwebr-output-code-stdout {
+    color: #111;
+  }
+
+  .qwebr-output-code-stderr {
+    color: #db4133;
+  }
+
+  .btn-qwebr {
     background-color: #EEEEEE;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0; /* Extra styling for consistency */
@@ -37,13 +45,13 @@
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
   }
 
-  .btn-webr:hover {
+  .btn-qwebr:hover {
     color: #000;
     background-color: #e3e6ea;
     border-color: #e1e5e9;
   }
 
-  .btn-webr:disabled,.btn-webr.disabled,fieldset:disabled .btn-webr {
+  .btn-qwebr:disabled,.btn-qwebr.disabled,fieldset:disabled .btn-qwebr {
     pointer-events: none;
     opacity: .65
   }
@@ -148,7 +156,7 @@
 
   // Function to set the button text
   function qwebrSetInteractiveButtonState(buttonText, enableCodeButton = true) {
-    document.querySelectorAll(".btn-webr").forEach((btn) => {
+    document.querySelectorAll(".btn-qwebr").forEach((btn) => {
       btn.innerHTML = buttonText;
       btn.disabled = !enableCodeButton;
     });

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -21,7 +21,7 @@
     color: #db4133;
   }
 
-  .btn-qwebr {
+  .qwebr-button-run {
     background-color: #EEEEEE;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0; /* Extra styling for consistency */
@@ -45,13 +45,13 @@
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
   }
 
-  .btn-qwebr:hover {
+  .qwebr-button-run:hover {
     color: #000;
     background-color: #e3e6ea;
     border-color: #e1e5e9;
   }
 
-  .btn-qwebr:disabled,.btn-qwebr.disabled,fieldset:disabled .btn-qwebr {
+  .qwebr-button-run:disabled,.qwebr-button-run.disabled,fieldset:disabled .qwebr-button-run {
     pointer-events: none;
     opacity: .65
   }
@@ -156,7 +156,7 @@
 
   // Function to set the button text
   function qwebrSetInteractiveButtonState(buttonText, enableCodeButton = true) {
-    document.querySelectorAll(".btn-qwebr").forEach((btn) => {
+    document.querySelectorAll(".qwebr-button-run").forEach((btn) => {
       btn.innerHTML = buttonText;
       btn.disabled = !enableCodeButton;
     });

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -49,16 +49,18 @@ website:
             text: Templates
           - href: qwebr-communication-channels.qmd
             text: Communication Channels
-      - section: "Extra"
+      - section: "Extra Information"
         contents:
+          - href: qwebr-release-notes.qmd
+            text: Release Notes
           - href: qwebr-acknowledgements.md
             text: Acknowledgements
           - href: qwebr-developer-resources.qmd
             text: Developer Resources
           - href: qwebr-extension-website.qmd
             text: Extension Website Notes
-          - href: qwebr-release-notes.qmd
-            text: Release Notes
+          - href: https://quarto-webr.thecoatlessprofessor.com/tests/
+            text: Test Suite
 
 format:
   html:

--- a/docs/qwebr-deployment-templates.qmd
+++ b/docs/qwebr-deployment-templates.qmd
@@ -26,6 +26,5 @@ This template is meant for building interactive websites with multiple webR-powe
 The book template is designed for creating interactive web-based books or documentation. It allows you to compile a collection of chapters, sections, and interactive content into a cohesive digital book.
 
 - **Example**: You can view an example of a book template [here](https://quarto-webr.thecoatlessprofessor.com/examples/book).
-
 - **Source Code**: Access the source code for this template [here](https://github.com/coatless/quarto-webr/tree/main/docs/examples/book).
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -14,7 +14,9 @@ format:
 
 - Added `autoload-packages` document meta option key that will automatically load packages specified in the `packages` key. The default value is `true`. ([#75](https://github.com/coatless/quarto-webr/issues/75))
   - This feature simplifies the use of packages, eliminating the need to call `library()` in interactive code cells or setup code cells, as the specified packages will be loaded automatically. 
-
+- Added new output classes to differentiate between STDOUT and STDERR text. ([#60](https://github.com/coatless/quarto-webr/issues/60))
+  - Error and warning messages will now appear red and regular output will appear black.
+  
 ## Bugfixes
 
 - Fix placement of the "WebR Status" indicator when in the `revealjs` presentation format. ([#84](https://github.com/coatless/quarto-webr/issues/84)).

--- a/examples/book/slide-embed.qmd
+++ b/examples/book/slide-embed.qmd
@@ -8,7 +8,7 @@ On this page, we show how we can embed a RevealJS Presentation inside of a Quart
 
 <div>
 ```{=html}
-<iframe class="slide-deck" src="../examples/revealjs/"></iframe>
+<iframe class="slide-deck" src="../revealjs/"></iframe>
 ```
 </div>
 

--- a/examples/website/slide-embed.qmd
+++ b/examples/website/slide-embed.qmd
@@ -8,7 +8,7 @@ On this page, we show how we can embed a RevealJS Presentation inside of a Quart
 
 <div>
 ```{=html}
-<iframe class="slide-deck" src="../examples/revealjs/"></iframe>
+<iframe class="slide-deck" src="../revealjs/"></iframe>
 ```
 </div>
 

--- a/tests/qwebr-test-help-documentation.qmd
+++ b/tests/qwebr-test-help-documentation.qmd
@@ -20,4 +20,3 @@ Test pager event support by verifying help documentation works in the interactiv
 #| context: output
 ?sd
 ```
-

--- a/tests/qwebr-test-internal-cell.qmd
+++ b/tests/qwebr-test-internal-cell.qmd
@@ -1,0 +1,41 @@
+---
+title: "Test: Cell Context Options"
+format: html
+engine: knitr
+filters:
+  - webr
+---
+
+Test page for verifying cell context options set explicitly with `context`. 
+
+## Interactive
+
+```{webr-r}
+#| context: interactive
+1 + 1
+```
+
+## Setup
+
+Hidden cell that sets `x` and `y` vector values.
+
+```{webr-r}
+#| context: setup
+x = c(1, 5, 3, -2)
+y = c(-5, 8, 9, 4)
+```
+
+## Output
+
+Hidden cell that retrieves previously set `x` and `y` vector values and displays the data.
+
+```{webr-r}
+#| context: output
+cat("x: ")
+print(x)
+
+cat("y: ")
+print(y)
+
+plot(x, y)
+```

--- a/tests/qwebr-test-output-classes.qmd
+++ b/tests/qwebr-test-output-classes.qmd
@@ -1,0 +1,32 @@
+---
+title: "Test: CSS Output Classes"
+format: html
+engine: knitr
+filters:
+  - webr
+---
+
+Test output classes for standard output and standard error.
+
+## Interactive
+
+```{webr-r}
+cat("Display letters: ")
+print(letters[1:5])
+
+warning("This is a warning message!")
+
+stop("This is a hard error message!")
+```
+
+## Non-interactive
+
+```{webr-r}
+#| context: output
+cat("Display letters: ")
+print(letters[1:5])
+
+warning("This is a warning message!")
+
+stop("This is a hard error message!")
+```

--- a/tests/qwebr-test-status-header-no-title.qmd
+++ b/tests/qwebr-test-status-header-no-title.qmd
@@ -6,3 +6,7 @@ filters:
 ---
 
 Ensure that the webR code cell initializes a status even if a title is omitted. 
+
+```{webr-r}
+print("Hello hidden title world!")
+```


### PR DESCRIPTION
In this PR, we add support for differentiating between `STDERR` and `STDOUT` output. Moreover, we re-arrange the output areas and add additional CSS classes.

Specifically, we now have the following layout and CSS classes.

<img width="1240" alt="annotated-qwebr-interactive" src="https://github.com/coatless/quarto-webr/assets/833642/3b08caef-cc0a-4c48-8208-a0156644e0da">

**Note:** Element IDs are extended from the classes shown, e.g. 

```
id="qwebr-interactive-area-1"
```

Shows the first tracked webR area in the document. This area can be either interactive or non-interactive.

Close #60.