### PR TITLE
RevealJS style tweaks

### DIFF
--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -32,7 +32,7 @@
       minimap: {
         enabled: false
       },
-      fontSize: '17.5rem',               // Bootstrap is 1 rem
+      fontSize: '17.5pt',               // Bootstrap is 1 rem
       renderLineHighlight: "none",     // Disable current line highlighting
       hideCursorInOverviewRuler: true  // Remove cursor indictor in right hand side scroll bar
     });

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -35,13 +35,14 @@
     -moz-text-decoration: none;
     -ms-text-decoration: none;
     -o-text-decoration: none;
-    vertical-align: middle;
+    /* vertical-align: middle; */ /* Prevents a space from appearing between the code cell and button */
     -webkit-user-select: none;
     border-color: #dee2e6;
     border: 1px solid rgba(0,0,0,0);
     padding: 0.375rem 0.75rem;
     font-size: 1rem;
-    border-radius: 0.25rem;
+    border-top-right-radius: 0.25rem;
+    border-top-left-radius: 0.25rem;
     transition: color .15s ease-in-out,background-color .15s ease-in-out,border-color .15s ease-in-out,box-shadow .15s ease-in-out;
   }
 
@@ -56,9 +57,42 @@
     opacity: .65
   }
 
+  /* Custom styling for RevealJS Presentations*/
+
+  /* Reset the style of the interactive area */
+  .reveal div.qwebr-interactive-area {
+    width: 100%;
+    height: 100%;
+    display: block;
+    box-shadow: none;
+    max-width: 100%;
+    max-height: 100%;
+    margin: 0;
+    padding: 0;
+  } 
+
+  /* Pad the right side by 10 px to avoid rubbing the border */
+  .reveal div.qwebr-output-code-area pre div {
+    padding: 0px 0px 0px 10px;
+  }
+
+  /* Collapse the inside code tags to avoid extra space between line outputs */
   .reveal pre div code.qwebr-output-code-stdout, .reveal pre div code.qwebr-output-code-stderr {
-    padding: 0px;
+    padding: 0;
     display: contents;
+  }
+
+  /* Create a border around console and output (does not effect graphs) */
+  .reveal div.qwebr-console-area {
+    border: 1px solid #EEEEEE;
+    box-shadow: 2px 2px 10px #EEEEEE;
+  }
+
+  /* Cap output height and allow text to scroll */
+  /* TODO: Is there a better way to fit contents/max it parallel to the monaco editor size? */
+  .reveal div.qwebr-output-code-area pre {
+    max-height: 400px;
+    overflow: scroll;
   }
 </style>
 

--- a/examples/revealjs/index.qmd
+++ b/examples/revealjs/index.qmd
@@ -25,6 +25,12 @@ fit = lm(mpg ~ wt, data = mtcars)
 summary(fit)
 ```
 
+## Graphing with webR
+
+```{webr-r}
+plot(pressure)
+```
+
 ## Keyboard Shortcuts
 
 - Run selected code using either:
@@ -57,6 +63,25 @@ You can embed the slide deck inside of a Quarto Website or Book by using:
 ```
 </div>
 ````
+
+## Embedded Slides: Demo
+
+Nested slides
+
+<style>
+.slide-deck {
+    border: 3px solid #dee2e6;
+    width: 100%;
+    height: 475px;
+}
+</style>
+
+<div>
+```{=html}
+<iframe class="slide-deck" src="index.html"></iframe>
+```
+</div>
+
 
 ## Fin
 


### PR DESCRIPTION
In this PR, we aim to try and solve some of the RevealJS slide cosmetics. 

For instance, we moved from: 

<img width="1912" alt="Old version of the RevealJS slide deck" src="https://github.com/coatless/quarto-webr/assets/833642/316764ca-ae86-4eca-8b6a-64f2cb8e6a55">

To: 

<img width="1887" alt="New version of the RevealJS integration" src="https://github.com/coatless/quarto-webr/assets/833642/c6cc3071-dede-4523-8d82-fc94471be7b3">

Main changes are a border around the "console area", padding on the right hand side of the output div, and allowing for scrolling on text overflow. 

What remains is to figure out how we can improve font sizing between the output area and monaco editor window...