### PR TITLE
Notes on global settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ summary(fit)
 
 The rendered document can be viewed online [here](https://quarto-webr.thecoatlessprofessor.com/examples/readme).
 
-When `quarto render` or `quarto preview` is called, the filter will execute under `engine: knitr`. 
-During the execution, the filter adds two files to the working directory: `webr-worker.js` and `webr-serviceworker.js`. These files allow for the 
-`webR` session to be started and must be present with the rendered output. 
-
  **Note:** If you don't specify the `engine: knitr`, the default compute engine used will be `jupyter`. This could trigger prompts to install Python. However, if you specify `engine: knitr`, there's no need to install Python.
 
 There are many more customization options that are available. Please see the [customization documentation](https://quarto-webr.thecoatlessprofessor.com/qwebr-meta-options.html) for more examples.

--- a/docs/qwebr-first-steps.qmd
+++ b/docs/qwebr-first-steps.qmd
@@ -71,8 +71,6 @@ summary(fit)
 If an engine is not specified, Quarto will attempt to use the `jupyter` compute engine by default. This may cause an error if `jupyter` is not installed on your computer.
 :::
 
-During execution, the filter will generate two essential files, `webr-worker.js` and `webr-serviceworker.js`, in your working directory. These files are required for the `webR` session to function properly under the default options and must be present alongside your rendered output.
-
 # Fin
 
 In summary, this guide has provided an overview of how to incorporate the `quarto-webr` extension into your Quarto HTML documents using RStudio. We began with a walkthrough video that offered an in-depth understanding of how this Quarto extension operates within the Quarto framework. Subsequently, we explored key workflow changes necessary for incorporating webR into your Quarto HTML documents, from installation to document rendering.

--- a/docs/qwebr-meta-options.qmd
+++ b/docs/qwebr-meta-options.qmd
@@ -12,11 +12,15 @@ aliases:
   - webr-meta-options.html
 ---
 
-The `quarto-webr` extension empowers you to tailor your webR environment to meet your unique requirements. By configuring various options in your document's YAML header, you can structure the webR experience on a per-page basis. Below, we explore these customization options and how to implement them.
+The `quarto-webr` extension empowers you to tailor your webR environment to meet your unique requirements. By configuring various options in your document's YAML header or `_quarto.yml` file, you can structure the webR experience on a per-page or per-project basis. Below, we explore these customization options and how to implement them.
 
 # Customization Options
 
-Enhance your webR experience by customizing its behavior through the `webr` key in your document's YAML header. These options allow you to fine-tune webR according to your specific needs.
+Enhance your webR experience by customizing its behavior through the `webr` key. This key should be added before listing the `filter` statement.
+
+## Document YAML
+
+To fine-tune webR to the specific needs of a document, place inside your document's YAML header the `webr` key. Specifying options this way allows webR to be setup with unique options confined to only that document.
 
 ```yaml
 ---
@@ -30,6 +34,33 @@ filters:
   - webr
 ---
 ```
+
+## Global Configuration
+
+If you have multiple pages that use webR, we suggest setting global options inside of the `_quarto.yml` file. This option is appropriate for Websites, Blogs, or Books. For instance, if you have a book project, the `_quarto.yml` should look like: 
+
+```yaml
+project:
+  type: book
+
+book:
+  title: "Sample quarto-webr Book Project"
+  # ... more options
+
+# Set default options for every bookpage that may or may not include webR.
+webr: 
+  show-startup-message: false     # Display status of webR initialization
+
+# Attach webR extension for the project
+filters:
+  - webr
+```
+
+:::{.callout-note}
+If a webR code cell is not present on a website, blog, or book page, then the `quarto-webr` extension will not setup webR on the page. 
+:::
+
+You can see full examples of setting a global option under the [Deployment Templates](qwebr-deployment-templates.qmd) page.
 
 ## webR options
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -21,11 +21,12 @@ format:
 ## Bugfixes
 
 - Fix line breaks inside of code output area inside of RevealJS.
-- Fix height of the RevealJS output area.
+- Fix height and presentation of the webR cell within RevealJS.  ([#98](https://github.com/coatless/quarto-webr/pulls/98))
 
 ## Documentation
 
-- Updated documentation to reflect the removal of `webr-worker.js` and `webr-serviceworker.js` scripts.
+- Updated documentation to reflect the removal of `webr-worker.js` and `webr-serviceworker.js` scripts. ([#59](https://github.com/coatless/quarto-webr/issues/59))
+- Added a section on setting global extension settings using `_quarto.yml` to the meta options ([#46](https://github.com/coatless/quarto-webr/issues/46))
 - Added slide embedding CSS class alongside examples.
 - Minor documentation tweaks.
 

--- a/tests/_quarto.yml
+++ b/tests/_quarto.yml
@@ -1,8 +1,5 @@
 project:
   type: website
-  resources:
-  - webr-serviceworker.js
-  - webr-worker.js
 
 website:
   title: "Test Suite for quarto-webr"

--- a/tests/qwebr-test-service-worker.qmd
+++ b/tests/qwebr-test-service-worker.qmd
@@ -1,0 +1,21 @@
+---
+title: "Test: Service Worker"
+format: 
+  html:
+    resources:
+      - webr-serviceworker.js
+      - webr-worker.js
+engine: knitr
+webr:
+  channel-type: "service-worker"
+filters:
+  - webr
+---
+
+This is a webr-enabled code cell in a Quarto HTML document that is set to use the service-worker option.
+
+```{webr-r}
+-3 + 5
+
+print("Hello service worker model!")
+```


### PR DESCRIPTION
In this PR, we:

- added notes to emphasize extension options can be set in `_quarto.yml` in addition to the Document Header. 
- cleaned up lingering instances of `webr-*worker.js` in README/first steps. 
- added test suite check for the `"service-worker"` option.