### PR TITLE
Fix Revealjs Output Class

### DIFF
--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -82,6 +82,15 @@
     display: contents;
   }
 
+  .reveal pre div code.qwebr-output-code-stdout {
+    color: #111;
+  }
+
+  .reveal pre div code.qwebr-output-code-stderr {
+    color: #db4133;
+  }
+
+
   /* Create a border around console and output (does not effect graphs) */
   .reveal div.qwebr-console-area {
     border: 1px solid #EEEEEE;

--- a/examples/revealjs/index.qmd
+++ b/examples/revealjs/index.qmd
@@ -31,6 +31,27 @@ summary(fit)
 plot(pressure)
 ```
 
+## Help Documentation
+
+```{webr-r}
+?mean
+```
+
+
+## Prints, Warnings, and Errors
+
+```{webr-r}
+cat("Hello there!\n")
+
+x = c(1, 2, 3)
+print(x)
+
+warning("Uh-oh, something is amiss")
+
+stop("I'm sorry Dave, I'm afraid I can't do that")
+```
+
+
 ## Keyboard Shortcuts
 
 - Run selected code using either:


### PR DESCRIPTION
Ensure that output classes set color under RevealJS

Adds more examples into the RevealJS slide deck.