### PR TITLE
Fix [Bug]: Too much space after webR block in RevealJS #102

### DIFF
--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -62,7 +62,6 @@
   /* Reset the style of the interactive area */
   .reveal div.qwebr-interactive-area {
     width: 100%;
-    height: 100%;
     display: block;
     box-shadow: none;
     max-width: 100%;

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -14,6 +14,8 @@ format:
 
 ## Bugfixes
 
+- Fix text added after code cell in RevealJS appearing off the page ([#102](https://github.com/coatless/quarto-webr/issues/102))
+
 ## Documentation 
 
 - Minor documentation tweaks.

--- a/tests/qwebr-test-revealjs.qmd
+++ b/tests/qwebr-test-revealjs.qmd
@@ -31,3 +31,13 @@ print("Hello quarto-webr RevealJS world!")
 
 3 + 5
 ```
+
+## Text Before and After Code Cell
+
+Sample text before
+
+```{webr-r}
+message("Hello World!")
+```
+
+Sample text after


### PR DESCRIPTION
Remove 100% height on interactive area

Before:

<img width="1104" alt="Screenshot 2023-11-17 at 12 23 21 AM" src="https://github.com/coatless/quarto-webr/assets/833642/8b76622c-d8c2-400e-be6e-07c422b29f81">

After:

<img width="901" alt="Screenshot 2023-11-17 at 12 21 45 AM" src="https://github.com/coatless/quarto-webr/assets/833642/440a3f89-c057-451b-9a3f-7c3a01af510b">
