### PR TITLE
Escape HTML output characters generated by R code output

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.4.0-dev.2
+version: 0.4.0-dev.3
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/webr-context-interactive.html
+++ b/_extensions/webr/webr-context-interactive.html
@@ -188,7 +188,7 @@
         .filter(evt => evt.type === "stdout" || evt.type === "stderr")
         .map((evt, index) => {
           const className = `qwebr-output-code-${evt.type}`;
-          return `<code id="${className}-editor-{{WEBRCOUNTER}}-result-${index + 1}" class="${className}">${evt.data}</code>`;
+          return `<code id="${className}-editor-{{WEBRCOUNTER}}-result-${index + 1}" class="${className}">${qwebrEscapeHTMLCharacters(evt.data)}</code>`;
         })
         .join("\n");
 

--- a/_extensions/webr/webr-context-output.html
+++ b/_extensions/webr/webr-context-output.html
@@ -72,7 +72,7 @@
         .filter(evt => evt.type === "stdout" || evt.type === "stderr")
         .map((evt, index) => {
           const className = `qwebr-output-code-${evt.type}`;
-          return `<code id="${className}-editor-{{WEBRCOUNTER}}-result-${index + 1}" class="${className}">${evt.data}</code>`;
+          return `<code id="${className}-editor-{{WEBRCOUNTER}}-result-${index + 1}" class="${className}">${qwebrEscapeHTMLCharacters(evt.data)}</code>`;
         })
         .join("\n");
 

--- a/_extensions/webr/webr-init.html
+++ b/_extensions/webr/webr-init.html
@@ -292,4 +292,14 @@
     true
   );
 
+  // Global version of the Escape HTML function that converts HTML 
+  // characters to their HTML entities.
+  globalThis.qwebrEscapeHTMLCharacters = function(unsafe) {
+    return unsafe
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  };
 </script>

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -19,6 +19,7 @@ format:
 
 ## Bugfixes
 
+- Prevented HTML output being shown as HTML by replacing HTML characters like `<`, `>`, `&`, etc., with their corresponding HTML entities. ([#115](https://github.com/coatless/quarto-webr/issues/115), h/t [@gvelasq](https://github.com/gvelasq))
 - Fixed display of text found after a code cell in RevealJS appearing off the page ([#102](https://github.com/coatless/quarto-webr/issues/102), [#106](https://github.com/coatless/quarto-webr/issues/106))
 
 ## Documentation 

--- a/tests/qwebr-test-escape-html-output-characters.qmd
+++ b/tests/qwebr-test-escape-html-output-characters.qmd
@@ -1,0 +1,34 @@
+---
+title: "Test: Escape Output with HTML Entities"
+format: html
+engine: knitr
+filters:
+  - webr
+---
+
+Ensure HTML output is escaped.
+
+## Interactive
+
+```{webr-r}
+# This function converts a markdown link into HTML
+"[Posit](https://posit.co)" |> (\(.) {
+  text <- sub("\\].*", "", sub(".*\\[", "", .))
+  url <- sub("\\).*", "", sub(".*\\(", "", .))
+  
+  writeLines(noquote(paste0('<a href="', url, '" target = "_blank">', text, '</a>')))
+})()
+```
+
+## Non-interactive
+
+```{webr-r}
+#| context: output
+# This function converts a markdown link into HTML
+"[Posit](https://posit.co)" |> (\(.) {
+  text <- sub("\\].*", "", sub(".*\\[", "", .))
+  url <- sub("\\).*", "", sub(".*\\(", "", .))
+  
+  writeLines(noquote(paste0('<a href="', url, '" target = "_blank">', text, '</a>')))
+})()
+```


### PR DESCRIPTION
This PR adds a JavaScript function that escapes HTML characters that may be contained within the R output. The characters being escaped alongside the new values are given in the following table:

| Original | Escaped   |
|----------|-----------|
| `&`      | `&amp;`   |
| `<`      | `&lt;`    |
| `>`      | `&gt;`    |
| `"`      | `&quot;`  |
| `'`      | `&#039;`  |

Thus, we now have: 

<img width="451" alt="qwebr-escaped-html-entities" src="https://github.com/coatless/quarto-webr/assets/833642/fe6b809c-a207-4703-955a-b058198c47b1">


Close #115 
