### PR TITLE
Patch EOL in MonacoEditor

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.4.0-dev.5
+version: 0.4.0-dev.6
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/qwebr-monaco-editor-element.js
+++ b/_extensions/webr/qwebr-monaco-editor-element.js
@@ -1,5 +1,5 @@
 // Global dictionary to store Monaco Editor instances
-const qwebrEditorInstances = {};
+globalThis.qwebrEditorInstances = {};
 
 // Function that builds and registers a Monaco Editor instance    
 globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
@@ -36,6 +36,17 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
 
     // Store the initial code value
     editor.__qwebrinitialCode = initialCode;
+
+    // Set at the model level the preferred end of line (EOL) character to LF.
+    // This prevent `\r\n` from being given to the webR engine if the user is on Windows.
+    // See details in: https://github.com/coatless/quarto-webr/issues/94
+    // Associated error text: 
+    // Error: <text>:1:7 unexpected input
+
+    // Retrieve the underlying model
+    const model = editor.getModel()
+    // Set EOL for the model
+    model.setEOL(monaco.editor.EndOfLineSequence.LF);
 
     // Dynamically modify the height of the editor window if new lines are added.
     let ignoreEvent = false;

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -33,7 +33,7 @@ format:
 - Prevented HTML output being shown as HTML by replacing HTML characters like `<`, `>`, `&`, etc., with their corresponding HTML entities. ([#115](https://github.com/coatless/quarto-webr/issues/115), h/t [@gvelasq](https://github.com/gvelasq))
 - Fixed display of text found after a code cell in RevealJS appearing off the page. ([#102](https://github.com/coatless/quarto-webr/issues/102), [#106](https://github.com/coatless/quarto-webr/issues/106))
 - Fixed `setup` and `output` contexts not syncing with values found in `packages`.   ([#114](https://github.com/coatless/quarto-webr/issues/114), [#105](https://github.com/coatless/quarto-webr/issues/105), [#88](https://github.com/coatless/quarto-webr/issues/88))
-
+- Fixed `unexpected input` error appearing spuriously on Windows machines by enforcing the end-of-line (EOL) character to be `LF` (`\n`) and, thus preventing `CRLF` (`\r\n`) from entering the picture. ([#94](https://github.com/coatless/quarto-webr/issues/94) huge thank you and h/t to [@ute](https://github.com/ute). Thanks also to [@alexCardazzi](https://github.com/alexCardazzi) for initial reporting).
 
 ## Documentation 
 


### PR DESCRIPTION
This patch forces values inside of the MonacoEditor to be `LF` (`\n`) instead of `CRLF` (`\r\n`)

Close #94