### PR TITLE
Ensure similar experience for `embed-resources: true` by simplifying link for FontAwesome

### DIFF
--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -402,7 +402,7 @@ local function ensureWebRSetup()
   -- Note: We're not able to use embed-resources due to the web assembly binary and the potential for additional service worker files.
   quarto.doc.include_text("in-header", [[
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.45.0/min/vs/editor/editor.main.css" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   ]])
 
   -- Insert the extension styling for defined elements

--- a/tests/qwebr-test-self-contained.qmd
+++ b/tests/qwebr-test-self-contained.qmd
@@ -1,0 +1,25 @@
+---
+title: "Test: embed-resources"
+format:
+  html:
+    embed-resources: true
+engine: knitr
+filters:
+  - webr
+---
+
+Ensure `embed-resources` option correctly puts a copy of FontAwesome in the document.
+
+## Interactive
+```{webr-r}
+1 + 1
+```
+
+## Non-interactive
+
+```{webr-r}
+#| context: output
+Sys.sleep(3)
+
+print("Sleep successful! Did you see the R logo?")
+```


### PR DESCRIPTION
Simplify the link to Cloudflare to ensure FontAwesome is able to be embedded into the document by Quarto using `embed-resources`