### PR TITLE
Add  `editor-quick-suggestions` option.

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.4.2-dev.2
+version: 0.4.2-dev.3
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/qwebr-monaco-editor-element.js
+++ b/_extensions/webr/qwebr-monaco-editor-element.js
@@ -30,7 +30,7 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
       renderLineHighlight: "none",     // Disable current line highlighting
       hideCursorInOverviewRuler: true,  // Remove cursor indictor in right hand side scroll bar
       readOnly: qwebrOptions['read-only'] ?? false,
-      quickSuggestions: qwebrOptions['editor-quick-suggestions'] ?? true
+      quickSuggestions: qwebrOptions['editor-quick-suggestions'] ?? false
     });
 
     // Store the official counter ID to be used in keyboard shortcuts

--- a/_extensions/webr/qwebr-monaco-editor-element.js
+++ b/_extensions/webr/qwebr-monaco-editor-element.js
@@ -29,7 +29,8 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
       fontSize: '17.5pt',              // Bootstrap is 1 rem
       renderLineHighlight: "none",     // Disable current line highlighting
       hideCursorInOverviewRuler: true,  // Remove cursor indictor in right hand side scroll bar
-      readOnly: qwebrOptions['read-only'] ?? false
+      readOnly: qwebrOptions['read-only'] ?? false,
+      quickSuggestions: qwebrOptions['editor-quick-suggestions'] ?? true
     });
 
     // Store the official counter ID to be used in keyboard shortcuts

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -73,7 +73,8 @@ local qwebRDefaultCellOptions = {
   ["fig-height"] = 5,
   ["out-width"] = "700px",
   ["out-height"] = "",
-  ["editor-max-height"] = ""
+  ["editor-max-height"] = "",
+  ["editor-quick-suggestions"] = "false"
 }
 
 ----

--- a/docs/qwebr-cell-options.qmd
+++ b/docs/qwebr-cell-options.qmd
@@ -33,17 +33,33 @@ The `{quarto-webr}` extension does not support all of the cell options from [Qua
 
 ## quarto-webr
 
-| Option      | Default Value | Description                                                                                                                                                                                                      |
-|-------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `context`   | `interactive` | Describe how the cell should operate on the page through either `interactive` (Runnable code editor), `output` (Output only of executed at runtime), or `setup` (execute code without seeing output at runtime). |
-| `autorun`   | `false`       | Allow `interactive` cells to be run during document initialization without a user pressing run code.                                                                                                             |
-| `read-only` | `false`       | Prevent code in `interactive` cells from being modified by disallowing code input.                                                                                                                               |
-| `editor-max-height` | `0`       | Set a threshold to prevent infinite growth of the editor window.                                                                                                                               |
+:::{.callout-note}
+Options listed here are unique to the `{quarto-webr}` extension and do not have a Quarto equivalent.
+:::
+
+### Run Options
+
+| Option                     | Default Value | Description                                                                                                                                                                                                      |
+|----------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `context`                  | `interactive` | Describe how the cell should operate on the page through either `interactive` (Runnable code editor), `output` (Output only of executed at runtime), or `setup` (execute code without seeing output at runtime). |
+| `autorun`                  | `false`       | Allow `interactive` cells to be run during document initialization without a user pressing run code.                                                                                                             |
 
 
 :::{.callout-note}
-Options listed here are unique to the `{quarto-webr}` extension. For details regarding `context`, please see [Hiding and Executing Code](qwebr-internal-cell.qmd).
+For details regarding run options, please see [Hiding and Executing Code](qwebr-internal-cell.qmd).
 :::
+
+
+### Monaco Editor Options
+
+| Option                     | Default Value | Description                                                                                                                                                                                                      |
+|----------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+| `read-only`                | `false`       | Prevent code in `interactive` cells from being modified by disallowing code input.                                                                                                                               |
+| `editor-max-height`        | `0`           | Set a threshold to prevent infinite growth of the editor window.                                                                                                                                                 |
+| `editor-quick-suggestions` | `false`       | Show a list of autocomplete variables and/or functions based on what was typed.                                                                                                                                  |
+
+
 
 ## Attributes
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -8,7 +8,7 @@ format:
     toc: true
 ---
 
-# 0.4.2-dev.2: ??????? (??-??-??)
+# 0.4.2-dev.3: ??????? (??-??-??)
 
 :::{.callout-note}
 Features listed under the `-dev` version have not yet been solidified and may change at any point.
@@ -18,9 +18,11 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 - Added `cell-options` document-level option to specify global defaults for `{webr-r}` options ([#173](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
 
-- Added `editor-max-height` cell option to limit growth of the editor window. ([#177](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
+- Added `editor-max-height` cell option to limit growth of the editor window. ([#177](https://github.com/coatless/quarto-webr/issues/177), thanks [ute](https://github.com/ute)!)
 
-- Added the ability to have the monaco editor switch between Quarto's light and dark theme modes. ([#176](https://github.com/coatless/quarto-webr/issues/176))
+- Added `editor-quick-suggestions` cell option to enable autocomplete menu suggestions. ([#182](https://github.com/coatless/quarto-webr/issues/182), thanks [egenn](https://github.com/egenn)!)
+
+- Added the ability to have the monaco editor switch between Quarto's light and dark theme modes. ([#176](https://github.com/coatless/quarto-webr/issues/176),)
 
 ## Bug fixes
 

--- a/tests/qwebr-test-editor-options.qmd
+++ b/tests/qwebr-test-editor-options.qmd
@@ -8,8 +8,7 @@ filters:
 
 Check that the editor responses correctly to options being set. 
 
-## Interactive
-
+## Adaptive Container Constraints 
 
 ### Single line
 
@@ -17,9 +16,7 @@ Check that the editor responses correctly to options being set.
 print("test")
 ```
 
-
 ### Uncapped height
-
 
 ```{webr-r}
 print("test")
@@ -28,7 +25,6 @@ print("test")
 c(1, 3, 4)
 print("line 5")
 ```
-
 
 ### Height cap
 
@@ -39,4 +35,15 @@ print("test")
 1 + 1
 c(1, 3, 4)
 print("line 5")
+```
+
+## Autosuggetions
+
+Opt-in to auto suggestions.
+
+```{webr-r}
+#| editor-quick-suggestions: true
+my_long_variable = 1
+
+prin
 ```


### PR DESCRIPTION
Allow setting Monaco editor `quickSuggestions` option using quarto `editor-quick-suggestions` option, 
defaulting to `true`.
solves #182 