### PR TITLE
Fix monaco editor options table in qwebr-cell-options.qmd

### DIFF
--- a/docs/qwebr-cell-options.qmd
+++ b/docs/qwebr-cell-options.qmd
@@ -52,13 +52,11 @@ For details regarding run options, please see [Hiding and Executing Code](qwebr-
 
 ### Monaco Editor Options
 
-| Option                     | Default Value | Description                                                                                                                                                                                                      |
-|----------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-
-| `read-only`                | `false`       | Prevent code in `interactive` cells from being modified by disallowing code input.                                                                                                                               |
-| `editor-max-height`        | `0`           | Set a threshold to prevent infinite growth of the editor window.                                                                                                                                                 |
-| `editor-quick-suggestions` | `false`       | Show a list of autocomplete variables and/or functions based on what was typed.                                                                                                                                  |
-
+| Option    | Default Value  | Description                                                                                         |
+|-----------|----------------|-----------------------------------------------------------------------------------------------------|
+| `read-only`                | `false`       | Prevent code in `interactive` cells from being modified by disallowing code input.  |
+| `editor-max-height`        | `0`           | Set a threshold to prevent infinite growth of the editor window.                    |
+| `editor-quick-suggestions` | `false`       | Show a list of autocomplete variables and/or functions based on what was typed.     |
 
 
 ## Attributes


### PR DESCRIPTION
tiny fix to render table