### PR TITLE
Upgrade from v0.3.2 to v0.3.3 of webR

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.4.2-dev.4
+version: 0.4.2-dev.5
 quarto-required: ">=1.2.198"
 contributes:
   filters:

--- a/_extensions/webr/webr-serviceworker.js
+++ b/_extensions/webr/webr-serviceworker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.3.2/webr-serviceworker.js');
+importScripts('https://webr.r-wasm.org/v0.3.3/webr-serviceworker.js');

--- a/_extensions/webr/webr-worker.js
+++ b/_extensions/webr/webr-worker.js
@@ -1,1 +1,1 @@
-importScripts('https://webr.r-wasm.org/v0.3.2/webr-worker.js');
+importScripts('https://webr.r-wasm.org/v0.3.3/webr-worker.js');

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -15,7 +15,7 @@ local hasDoneWebRSetup = false
 
 --- Define a base compatibile version
 ---@type string
-local baseVersionWebR = "0.3.2"
+local baseVersionWebR = "0.3.3"
 
 --- Define where webR can be found
 ---@type string

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -16,7 +16,7 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 ## Features
 
-- Upgraded to webR v0.3.3 ([#187](https://github.com/coatless/quarto-webr/pulls/187))
+- Upgraded to webR v0.3.3 ([#196](https://github.com/coatless/quarto-webr/pulls/196))
 
 - Upgraded to webR v0.3.2 ([#187](https://github.com/coatless/quarto-webr/issues/187))
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -8,7 +8,7 @@ format:
     toc: true
 ---
 
-# 0.4.2-dev.3: ??????? (??-??-??)
+# 0.4.2-dev.5: ??????? (??-??-??)
 
 :::{.callout-note}
 Features listed under the `-dev` version have not yet been solidified and may change at any point.
@@ -16,7 +16,9 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 ## Features
 
-- Upgraded to webR v0.3.2 ([#187](https://github.com/coatless/quarto-webr/issues/187)!)
+- Upgraded to webR v0.3.3 ([#187](https://github.com/coatless/quarto-webr/pulls/187))
+
+- Upgraded to webR v0.3.2 ([#187](https://github.com/coatless/quarto-webr/issues/187))
 
 - Added `cell-options` document-level option to specify global defaults for `{webr-r}` options ([#173](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
 


### PR DESCRIPTION
This PR upgrades the version of `webR` being used by the `{quarto-webr}` extension.