### PR TITLE
Modify editor font scale size defaults for HTML vs revealjs presentations

### DIFF
--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -91,7 +91,7 @@ local qwebRDefaultCellOptions = {
   ["fig-height"] = 5,
   ["out-width"] = "700px",
   ["out-height"] = "",
-  ["editor-font-scale"] = 1,
+  ["editor-font-scale"] = quarto.doc.is_format("revealjs") and "0.5" or "1",
   ["editor-max-height"] = "",
   ["editor-quick-suggestions"] = "false"
 }

--- a/docs/qwebr-cell-options.qmd
+++ b/docs/qwebr-cell-options.qmd
@@ -52,11 +52,12 @@ For details regarding run options, please see [Hiding and Executing Code](qwebr-
 
 ### Monaco Editor Options
 
-| Option    | Default Value  | Description                                                                                         |
-|-----------|----------------|-----------------------------------------------------------------------------------------------------|
-| `read-only`                | `false`       | Prevent code in `interactive` cells from being modified by disallowing code input.  |
-| `editor-max-height`        | `0`           | Set a threshold to prevent infinite growth of the editor window.                    |
-| `editor-quick-suggestions` | `false`       | Show a list of autocomplete variables and/or functions based on what was typed.     |
+| Option                     | Default Value | Description                                                                                                                                                       |
+|----------------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `read-only`                | `false`       | Prevent code in `interactive` cells from being modified by disallowing code input.                                                                                |
+| `editor-max-height`        | `0`           | Set a threshold to prevent infinite growth of the editor window.                                                                                                  |
+| `editor-quick-suggestions` | `false`       | Show a list of autocomplete variables and/or functions based on what was typed.                                                                                   |
+| `editor-font-scale`        | `1`           | Modify the size of code cell and output relative to the page font size. Values less than 1 shrink the text size and values greater than 1 increase the text size. |
 
 
 ## Attributes

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -31,6 +31,8 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 - Added `editor-max-height` cell option to limit growth of the editor window. ([#177](https://github.com/coatless/quarto-webr/issues/177), thanks [ute](https://github.com/ute)!)
 
+- Added `editor-font-scale` cell option to scale the code cell size relative to the page font size. Default is `1` for HTML Documents, Books, and Websites and `0.5` for Revealjs Slides. ([#172](https://github.com/coatless/quarto-webr/issues/172) & [#209](https://github.com/coatless/quarto-webr/pull/209), thanks [ute](https://github.com/ute)!)
+
 - Added `editor-quick-suggestions` cell option to enable autocomplete menu suggestions. ([#182](https://github.com/coatless/quarto-webr/issues/182), thanks [egenn](https://github.com/egenn)!)
 
 - Added the ability to have the monaco editor switch between Quarto's light and dark theme modes. ([#176](https://github.com/coatless/quarto-webr/issues/176))


### PR DESCRIPTION
Add to cell option table `editor-font-scale` documentation

Modify default to be variable depending on the quarto format detected. 

- HTML Documents, Books, Websites, Blogs: 1
- Revealjs: 0.5
