### PR TITLE
Add Rhistory tracking

### DIFF
--- a/_extensions/webr/qwebr-cell-initialization.js
+++ b/_extensions/webr/qwebr-cell-initialization.js
@@ -78,6 +78,10 @@ qwebrInstance.then(
           break;
         case 'setup':
           const activeDiv = document.getElementById(`qwebr-noninteractive-setup-area-${qwebrCounter}`);
+
+          // Store code in history
+          qwebrLogCodeToHistory(cellCode, entry.options);
+
           // Run the code in a non-interactive state with all output thrown away
           await mainWebR.evalRVoid(`${cellCode}`);
           break;

--- a/_extensions/webr/qwebr-compute-engine.js
+++ b/_extensions/webr/qwebr-compute-engine.js
@@ -24,6 +24,13 @@ globalThis.qwebrPrefixComment = function(x, comment) {
     return `${comment}${x}`;
 };
 
+// Function to store the code in the history
+globalThis.qwebrLogCodeToHistory = function(codeToRun, options) {
+    qwebrRCommandHistory.push(
+        `# Ran code in ${options.label} at ${new Date().toLocaleString()} ----\n${codeToRun}`
+    );
+}
+
 // Function to parse the pager results
 globalThis.qwebrParseTypePager = async function (msg) { 
 
@@ -112,6 +119,9 @@ globalThis.qwebrComputeEngine = async function(
         // Disable generating graphics
         captureOutputOptions.captureGraphics = false;
     }
+
+    // Store the code to run in history
+    qwebrLogCodeToHistory(codeToRun, options);
 
     // Setup a webR canvas by making a namespace call into the {webr} package
     // Evaluate the R code

--- a/_extensions/webr/qwebr-document-history.js
+++ b/_extensions/webr/qwebr-document-history.js
@@ -14,7 +14,7 @@ globalThis.qwebrFormatRHistory = function() {
 const command_history_modal = document.getElementById("qwebr-history-modal");
 
 // Get the button that opens the command modal
-const command_history_btn = document.getElementById("qwebRRHistoryButton");
+const command_history_btn = document.getElementById("qwebrRHistoryButton");
 
 // Get the <span> element that closes the command modal
 const command_history_close_span = document.getElementById("qwebr-command-history-close-btn");

--- a/_extensions/webr/qwebr-document-history.js
+++ b/_extensions/webr/qwebr-document-history.js
@@ -29,6 +29,21 @@ function populateCommandHistoryModal() {
     document.getElementById("qwebr-command-history-contents").innerHTML = qwebrFormatRHistory() || "No commands have been executed yet.";
 }
 
+// Function to format the current date and time to
+// a string with the format YYYY-MM-DD-HH-MM-SS
+function formatDateTime() {
+    const now = new Date();
+
+    const year = now.getFullYear();
+    const day = String(now.getDate()).padStart(2, '0');
+    const month = String(now.getMonth() + 1).padStart(2, '0'); // Months are zero-based
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    const seconds = String(now.getSeconds()).padStart(2, '0');
+
+    return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
+}
+
 
 // Function to convert document title with datetime to a safe filename
 function safeFileName() {
@@ -36,10 +51,10 @@ function safeFileName() {
     let pageTitle = document.title;
 
     // Combine the current page title with the current date and time
-    let pageNameWithDateTime = `Rhistory-${pageTitle}-${new Date().toISOString()}`;
+    let pageNameWithDateTime = `Rhistory-${pageTitle}-${formatDateTime()}`;
 
     // Replace unsafe characters with safe alternatives
-    let safeFilename = decodeURI(pageNameWithDateTime);
+    let safeFilename = pageNameWithDateTime.replace(/[\\/:\*\?! "<>\|]/g, '-');
 
     return safeFilename;
 }

--- a/_extensions/webr/qwebr-document-history.js
+++ b/_extensions/webr/qwebr-document-history.js
@@ -1,0 +1,95 @@
+// Define a global storage and retrieval solution ----
+
+// Store commands executed in R
+globalThis.qwebrRCommandHistory = [];
+
+// Function to retrieve the command history
+globalThis.qwebrFormatRHistory = function() {
+   return qwebrRCommandHistory.join("\n\n");
+}
+
+// Retrieve HTML Elements ----
+
+// Get the command modal
+const command_history_modal = document.getElementById("qwebr-history-modal");
+
+// Get the button that opens the command modal
+const command_history_btn = document.getElementById("qwebRRHistoryButton");
+
+// Get the <span> element that closes the command modal
+const command_history_close_span = document.getElementById("qwebr-command-history-close-btn");
+
+// Get the download button for r history information
+const command_history_download_btn = document.getElementById("qwebr-download-history-btn");
+
+// Plug in command history into modal/download button ----
+
+// Function to populate the modal with command history
+function populateCommandHistoryModal() {
+    document.getElementById("qwebr-command-history-contents").innerHTML = qwebrFormatRHistory() || "No commands have been executed yet.";
+}
+
+
+// Function to convert document title with datetime to a safe filename
+function safeFileName() {
+    // Get the current page title
+    let pageTitle = document.title;
+
+    // Combine the current page title with the current date and time
+    let pageNameWithDateTime = `Rhistory-${pageTitle}-${new Date().toISOString()}`;
+
+    // Replace unsafe characters with safe alternatives
+    let safeFilename = decodeURI(pageNameWithDateTime);
+
+    return safeFilename;
+}
+
+
+// Function to download list contents as text file
+function downloadRHistory() {
+    // Get the current page title + datetime and use it as the filename
+    const filename = `${safeFileName()}.R`;
+
+    // Get the text contents of the R History list
+    const text = qwebrFormatRHistory();
+
+    // Create a new Blob object with the text contents
+    const blob = new Blob([text], { type: 'text/plain' });
+  
+    // Create a new anchor element for the download
+    const a = document.createElement('a');
+    a.style.display = 'none';
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+
+    // Append the anchor to the body, click it, and remove it
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+}
+
+// Register event handlers ----
+
+// When the user clicks the View R History button, open the command modal
+command_history_btn.onclick = function() {
+    populateCommandHistoryModal();
+    command_history_modal.style.display = "block";
+}
+
+// When the user clicks on <span> (x), close the command modal
+command_history_close_span.onclick = function() {
+    command_history_modal.style.display = "none";
+}
+
+// When the user clicks anywhere outside of the command modal, close it
+window.onclick = function(event) {
+    if (event.target == command_history_modal) {
+        command_history_modal.style.display = "none";
+    }
+}
+
+// Add an onclick event listener to the download button so that
+// the user can download the R history as a text file
+command_history_download_btn.onclick = function() {
+    downloadRHistory();
+};

--- a/_extensions/webr/qwebr-document-status.js
+++ b/_extensions/webr/qwebr-document-status.js
@@ -28,6 +28,41 @@ globalThis.qwebrUpdateStatusHeader = function(message) {
     <span>${message}</span>`;
 }
 
+// Function to return true if element is found, false if not
+globalThis.qwebrCheckHTMLElementExists = function(selector) {
+  const element = document.querySelector(selector);
+  return !!element;
+}
+
+// Function that detects whether reveal.js slides are present
+globalThis.qwebrIsRevealJS = function() {
+  // If the '.reveal .slides' selector exists, RevealJS is likely present
+  return qwebrCheckHTMLElementExists('.reveal .slides');
+}
+
+// Initialize the Quarto sidebar element
+function qwebrSetupQuartoSidebar() {
+  var newSideBarDiv = document.createElement('div');
+  newSideBarDiv.id = 'quarto-margin-sidebar';
+  newSideBarDiv.className = 'sidebar margin-sidebar';
+  newSideBarDiv.style.top = '0px';
+  newSideBarDiv.style.maxHeight = 'calc(0px + 100vh)';
+
+  return newSideBarDiv;
+}
+
+// Position the sidebar in the document
+function qwebrPlaceQuartoSidebar() {
+  // Get the reference to the element with id 'quarto-document-content'
+  var referenceNode = document.getElementById('quarto-document-content');
+
+  // Create the new div element
+  var newSideBarDiv = qwebrSetupQuartoSidebar();
+
+  // Insert the new div before the 'quarto-document-content' element
+  referenceNode.parentNode.insertBefore(newSideBarDiv, referenceNode);
+}
+
 function qwebrPlaceMessageContents(content, html_location = "title-block-header", revealjs_location = "title-slide") {
 
   // Get references to header elements
@@ -47,6 +82,7 @@ function qwebrPlaceMessageContents(content, html_location = "title-block-header"
     monacoScript.after(header);
   }
 }
+
 
 
 function qwebrOffScreenCanvasSupportWarningMessage() {
@@ -153,6 +189,175 @@ function displayStartupMessage(showStartupMessage, showHeaderMessage) {
   // Place message on webpage
   qwebrPlaceMessageContents(quartoTitleMeta); 
 }
+
+function qwebrAddCommandHistoryModal() {
+  // Create the modal div
+  var modalDiv = document.createElement('div');
+  modalDiv.id = 'qwebr-history-modal';
+  modalDiv.className = 'qwebr-modal';
+
+  // Create the modal content div
+  var modalContentDiv = document.createElement('div');
+  modalContentDiv.className = 'qwebr-modal-content';
+
+  // Create the span for closing the modal
+  var closeSpan = document.createElement('span');
+  closeSpan.id = 'qwebr-command-history-close-btn';
+  closeSpan.className = 'qwebr-modal-close';
+  closeSpan.innerHTML = '&times;';
+
+  // Create the h1 element for the modal
+  var modalH1 = document.createElement('h1');
+  modalH1.textContent = 'R History Command Contents';
+
+  // Create an anchor element for downloading the Rhistory file 
+  var downloadLink = document.createElement('a');
+  downloadLink.href = '#';
+  downloadLink.id = 'qwebr-download-history-btn';
+  downloadLink.className = 'qwebr-download-btn';
+
+  // Create an 'i' element for the icon
+  var icon = document.createElement('i');
+  icon.className = 'bi bi-file-code';
+
+  // Append the icon to the anchor element
+  downloadLink.appendChild(icon);
+
+  // Add the text 'Download R History' to the anchor element
+  downloadLink.appendChild(document.createTextNode(' Download R History File'));
+
+  // Create the pre for command history contents
+  var commandContentsPre = document.createElement('pre');
+  commandContentsPre.id = 'qwebr-command-history-contents';
+  commandContentsPre.className = 'qwebr-modal-content-code';
+
+  // Append the close span, h1, and history contents pre to the modal content div
+  modalContentDiv.appendChild(closeSpan);
+  modalContentDiv.appendChild(modalH1);
+  modalContentDiv.appendChild(downloadLink);
+  modalContentDiv.appendChild(commandContentsPre);
+
+  // Append the modal content div to the modal div
+  modalDiv.appendChild(modalContentDiv);
+
+  // Append the modal div to the body
+  document.body.appendChild(modalDiv);
+}
+
+function qwebrRegisterRevealJSCommandHistoryModal() {
+  // Select the <ul> element inside the <div> with data-panel="Custom0"
+  let ulElement = document.querySelector('div[data-panel="Custom0"] > ul.slide-menu-items');
+
+  // Find the last <li> element with class slide-tool-item
+  let lastItem = ulElement.querySelector('li.slide-tool-item:last-child');
+
+  // Calculate the next data-item value
+  let nextItemValue = 0;
+  if (lastItem) {
+      nextItemValue = parseInt(lastItem.dataset.item) + 1;
+  }
+
+  // Create a new <li> element
+  let newListItem = document.createElement('li');
+  newListItem.className = 'slide-tool-item';
+  newListItem.dataset.item = nextItemValue.toString(); // Set the next available data-item value
+
+  // Create the <a> element inside the <li>
+  let newLink = document.createElement('a');
+  newLink.href = '#';
+  newLink.id = 'qwebRRHistoryButton'; // Set the ID for the new link
+  
+  // Create the <kbd> element inside the <a>
+  let newKbd = document.createElement('kbd');
+  newKbd.textContent = ' '; // Set to empty as we are not registering a keyboard shortcut
+
+  // Create text node for the link text
+  let newText = document.createTextNode(' View R History');
+
+  // Append <kbd> and text node to <a>
+  newLink.appendChild(newKbd);
+  newLink.appendChild(newText);
+
+  // Append <a> to <li>
+  newListItem.appendChild(newLink);
+
+  // Append <li> to <ul>
+  ulElement.appendChild(newListItem);
+}
+
+// Handle setting up the R history modal
+function qwebrCodeLinks() {
+
+  if (qwebrIsRevealJS()) {
+    qwebrRegisterRevealJSCommandHistoryModal();
+    return;
+  }
+
+  // Create the container div
+  var containerDiv = document.createElement('div');
+  containerDiv.className = 'quarto-code-links';
+
+  // Create the h2 element
+  var h2 = document.createElement('h2');
+  h2.textContent = 'QWebR Code Links';
+
+  // Create the ul element
+  var ul = document.createElement('ul');
+
+  // Create the li element
+  var li = document.createElement('li');
+
+  // Create the a_history_btn element
+  var a_history_btn = document.createElement('a');
+  a_history_btn.href = 'javascript:void(0)';
+  a_history_btn.setAttribute('id', 'qwebRRHistoryButton');
+
+  // Create the i_history_btn element
+  var i_history_btn = document.createElement('i');
+  i_history_btn.className = 'bi bi-file-code';
+
+  // Create the text node for the link text
+  var text_history_btn = document.createTextNode('View R History');
+
+  // Append the icon element and link text to the a element
+  a_history_btn.appendChild(i_history_btn);
+  a_history_btn.appendChild(text_history_btn);
+
+  // Append the a element to the li element
+  li.appendChild(a_history_btn);
+
+  // Append the li element to the ul element
+  ul.appendChild(li);
+
+  // Append the h2 and ul elements to the container div
+  containerDiv.appendChild(h2);
+  containerDiv.appendChild(ul);
+
+  // Append the container div to the element with the ID 'quarto-margin-sidebar'
+  var sidebar = document.getElementById('quarto-margin-sidebar');
+    
+  // If the sidebar element is not found, create it
+  if(!sidebar) {
+    qwebrPlaceQuartoSidebar();
+  }
+    
+  // Re-select the sidebar element (if it was just created)
+  sidebar = document.getElementById('quarto-margin-sidebar');   
+  
+  // Check if the sidebar element exists
+  if(!sidebar) {
+    // Append the container div to the sidebar
+    sidebar.appendChild(containerDiv);
+  } else {
+    console.warn('Element with ID "quarto-margin-sidebar" not found.');
+  }
+}
+
+// Call the function to append the code links for qwebR into the right sidebar
+qwebrCodeLinks();
+
+// Add the command history modal
+qwebrAddCommandHistoryModal();
 
 displayStartupMessage(qwebrShowStartupMessage, qwebrShowHeaderMessage);
 qwebrOffScreenCanvasSupportWarningMessage();

--- a/_extensions/webr/qwebr-document-status.js
+++ b/_extensions/webr/qwebr-document-status.js
@@ -265,7 +265,7 @@ function qwebrRegisterRevealJSCommandHistoryModal() {
   // Create the <a> element inside the <li>
   let newLink = document.createElement('a');
   newLink.href = '#';
-  newLink.id = 'qwebRRHistoryButton'; // Set the ID for the new link
+  newLink.id = 'qwebrRHistoryButton'; // Set the ID for the new link
   
   // Create the <kbd> element inside the <a>
   let newKbd = document.createElement('kbd');
@@ -299,7 +299,7 @@ function qwebrCodeLinks() {
 
   // Create the h2 element
   var h2 = document.createElement('h2');
-  h2.textContent = 'QWebR Code Links';
+  h2.textContent = 'webR Code Links';
 
   // Create the ul element
   var ul = document.createElement('ul');
@@ -310,7 +310,7 @@ function qwebrCodeLinks() {
   // Create the a_history_btn element
   var a_history_btn = document.createElement('a');
   a_history_btn.href = 'javascript:void(0)';
-  a_history_btn.setAttribute('id', 'qwebRRHistoryButton');
+  a_history_btn.setAttribute('id', 'qwebrRHistoryButton');
 
   // Create the i_history_btn element
   var i_history_btn = document.createElement('i');
@@ -340,15 +340,17 @@ function qwebrCodeLinks() {
   if(!sidebar) {
     qwebrPlaceQuartoSidebar();
   }
-    
+  
   // Re-select the sidebar element (if it was just created)
   sidebar = document.getElementById('quarto-margin-sidebar');   
-  
-  // Check if the sidebar element exists
-  if(!sidebar) {
+
+
+  // If the sidebar element exists, append the container div to it
+  if(sidebar) {
     // Append the container div to the sidebar
     sidebar.appendChild(containerDiv);
   } else {
+    // Get a debugger ...
     console.warn('Element with ID "quarto-margin-sidebar" not found.');
   }
 }

--- a/_extensions/webr/qwebr-styling.css
+++ b/_extensions/webr/qwebr-styling.css
@@ -116,6 +116,58 @@ body.quarto-dark .qwebr-button:hover {
   color: #696969;
 }
 
+/* Style the modal pop-up */
+
+/* The Modal (background) */
+.qwebr-modal {
+  display: none; /* Hidden by default */
+  position: fixed; /* Stay in place */
+  z-index: 1; /* Sit on top */
+  left: 0;
+  top: 0;
+  width: 100%; /* Full width */
+  height: 100%; /* Full height */
+  overflow: auto; /* Enable scroll if needed */
+  background-color: rgb(0,0,0); /* Fallback color */
+  background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+  padding-top: 60px;
+}
+
+/* Modal Content */
+.qwebr-modal-content {
+  background-color: #fefefe;
+  margin: 5% auto; /* 15% from the top and centered */
+  padding: 20px;
+  border: 1px solid #888;
+  width: 80%; /* Could be more or less, depending on screen size */
+}
+
+.qwebr-modal-content-code {
+  max-height: 50vh;
+  min-height: 5vh;
+  overflow: scroll;
+  border: 1px solid #888;
+}
+
+/* The Close Button */
+.qwebr-modal-close {
+  color: #aaa;
+  float: right;
+  font-size: 28px;
+  font-weight: bold;
+}
+
+.qwebr-modal-close:hover,
+.qwebr-modal-close:focus {
+  color: black;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.qwebr-download-btn {
+  margin-top: 10px;
+  text-decoration: none !important;
+}
 
 /* Custom styling for RevealJS Presentations*/
 

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -522,6 +522,9 @@ local function ensureWebRSetup()
   -- Insert JS routine to add document status header
   includeFileInHTMLTag("in-header", "qwebr-document-status.js", "js")
 
+  -- Insert the document history script
+  includeFileInHTMLTag("in-header", "qwebr-document-history.js", "js")
+
   -- Insert the extension element creation scripts
   includeFileInHTMLTag("in-header", "qwebr-cell-elements.js", "js")
 

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -8,7 +8,7 @@ format:
     toc: true
 ---
 
-# 0.4.2-dev.6: ??????? (??-??-??)
+# 0.4.2-dev.7: ??????? (??-??-??)
 
 :::{.callout-note}
 Features listed under the `-dev` version have not yet been solidified and may change at any point.
@@ -23,10 +23,7 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 - Upgraded to webR v0.3.3 ([#196](https://github.com/coatless/quarto-webr/pulls/196))
 
-- Upgraded to webR v0.3.2 ([#187](https://github.com/coatless/quarto-webr/issues/187))
-
-- Increase the minimum Quarto version requirement to 1.4.554.  ([#198](https://github.com/coatless/quarto-webr/issues/198)).
-
+- Added ability to download the R history of commands executed through a new global menu in the right column and underneath Revealjs' "Tools" menu. ([#148](https://github.com/coatless/quarto-webr/issues/148))
 
 - Added `cell-options` document-level option to specify global defaults for `{webr-r}` options ([#173](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
 
@@ -47,6 +44,8 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 ## Changes
 
+- Increase the minimum Quarto version requirement to 1.4.554.  ([#198](https://github.com/coatless/quarto-webr/issues/198)).
+- Upgraded to webR v0.3.2 ([#187](https://github.com/coatless/quarto-webr/issues/187))
 - Added [Lua type annotations](https://luals.github.io/wiki/annotations/) and function documentation into the Quarto extensions' Lua filter. ([#190](https://github.com/coatless/quarto-webr/pulls/190))
 - Avoided distributing `webr-serviceworker.js` and `webr-worker.js` when `channel-type` is not `service-worker`. ([#210](https://github.com/coatless/quarto-webr/pulls/210))
 - Dynamically write `webr-serviceworker.js` and `webr-worker.js` files based on the version chosen ([#212](https://github.com/coatless/quarto-webr/pulls/212))


### PR DESCRIPTION
This PR creates a new global tool menu on the right hand side of the Quarto HTML page similar to what is offered for [Including Other Formats](https://quarto.org/docs/output-formats/html-multi-format.html) and [Code Links and Other Links](https://quarto.org/docs/output-formats/html-basics.html#code-links-and-other-links). 

![qwebr-demo-r-history-revealjs](https://github.com/coatless/quarto-webr/assets/833642/d07c6260-5191-4461-b774-21a6a67e2cf7)

![qwebr-demo-r-history-html](https://github.com/coatless/quarto-webr/assets/833642/4e650f7d-807c-4a4e-8f15-8fc541808e13)



Close #148 