### PR TITLE
Enable wordWrap in the monaco editor by default.

### DIFF
--- a/_extensions/webr/qwebr-monaco-editor-element.js
+++ b/_extensions/webr/qwebr-monaco-editor-element.js
@@ -30,7 +30,8 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
       renderLineHighlight: "none",      // Disable current line highlighting
       hideCursorInOverviewRuler: true,  // Remove cursor indictor in right hand side scroll bar
       readOnly: qwebrOptions['read-only'] ?? false,
-      quickSuggestions: qwebrOptions['editor-quick-suggestions'] ?? false
+      quickSuggestions: qwebrOptions['editor-quick-suggestions'] ?? false,
+      wordWrap: (qwebrOptions['editor-word-wrap'] == 'true' ? "on" : "off")
     });
 
     // Store the official counter ID to be used in keyboard shortcuts

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -93,7 +93,8 @@ local qwebRDefaultCellOptions = {
   ["out-height"] = "",
   ["editor-font-scale"] = quarto.doc.is_format("revealjs") and "0.5" or "1",
   ["editor-max-height"] = "",
-  ["editor-quick-suggestions"] = "false"
+  ["editor-quick-suggestions"] = "false",
+  ["editor-word-wrap"] = "true"
 }
 
 -----

--- a/docs/qwebr-cell-options.qmd
+++ b/docs/qwebr-cell-options.qmd
@@ -58,6 +58,8 @@ For details regarding run options, please see [Hiding and Executing Code](qwebr-
 | `editor-max-height`        | `0`           | Set a threshold to prevent infinite growth of the editor window.                                                                                                  |
 | `editor-quick-suggestions` | `false`       | Show a list of autocomplete variables and/or functions based on what was typed.                                                                                   |
 | `editor-font-scale`        | `1`           | Modify the size of code cell and output relative to the page font size. Values less than 1 shrink the text size and values greater than 1 increase the text size. |
+| `editor-word-wrap`         | `true`        | Allow long lines to be wrapped to avoid code going off the screen causing a scroll bar to appear.                                                                 |
+
 
 
 ## Attributes

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -29,13 +29,15 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 - Added `cell-options` document-level option to specify global defaults for `{webr-r}` options ([#173](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
 
-- Added `version` document-level option to specify what version of webR should be used. ([#211](https://github.com/coatless/quarto-webr/issues/211))
+- Added `version` document-level option to specify what version of webR should be used. Default embedded version. ([#211](https://github.com/coatless/quarto-webr/issues/211))
 
 - Added `editor-max-height` cell option to limit growth of the editor window. ([#177](https://github.com/coatless/quarto-webr/issues/177), thanks [ute](https://github.com/ute)!)
 
 - Added `editor-font-scale` cell option to scale the code cell size relative to the page font size. Default is `1` for HTML Documents, Books, and Websites and `0.5` for Revealjs Slides. ([#172](https://github.com/coatless/quarto-webr/issues/172) & [#209](https://github.com/coatless/quarto-webr/pull/209), thanks [ute](https://github.com/ute)!)
 
-- Added `editor-quick-suggestions` cell option to enable autocomplete menu suggestions. ([#182](https://github.com/coatless/quarto-webr/issues/182), thanks [egenn](https://github.com/egenn)!)
+- Added `editor-quick-suggestions` cell option to enable autocomplete menu suggestions. Default `"false"`.([#182](https://github.com/coatless/quarto-webr/issues/182), thanks [egenn](https://github.com/egenn)!)
+
+- Added `editor-word-wrap` cell option to allow long lines to be wrapped inside of the code cell. Default `"true"`. ([#38](https://github.com/coatless/quarto-webr/issues/38))
 
 - Added the ability to have the monaco editor switch between Quarto's light and dark theme modes. ([#176](https://github.com/coatless/quarto-webr/issues/176))
 


### PR DESCRIPTION

## editor-word-wrap: true

<img width="681" alt="Monaco editor with word wrap enabled allowing for content to be shown together" src="https://github.com/coatless/quarto-webr/assets/833642/5fe92827-6b66-448f-b74a-bdeba4246b79">

## editor-word-wrap: false
<img width="838" alt="Monaco editor with word wrap disable causing a scroll bar to appear" src="https://github.com/coatless/quarto-webr/assets/833642/f0cd5ab4-0167-4538-b150-1880963693b6">

Close #38