### PR TITLE
Line highlighting

### DIFF
--- a/_extensions/webr/qwebr-monaco-editor-element.js
+++ b/_extensions/webr/qwebr-monaco-editor-element.js
@@ -1,6 +1,12 @@
 // Global array to store Monaco Editor instances
 globalThis.qwebrEditorInstances = [];
 
+function isValidCodeLineNumbers(stringCodeLineNumbers) {
+  // Regular expression to match valid input strings
+  const regex = /^(\d+(-\d+)?)(,\d+(-\d+)?)*$/;
+  return regex.test(stringCodeLineNumbers);
+}
+
 // Function that builds and registers a Monaco Editor instance    
 globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
 
@@ -54,7 +60,7 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
     const model = editor.getModel();
     // Set EOL for the model
     model.setEOL(monaco.editor.EndOfLineSequence.LF);
-
+    
     // Dynamically modify the height of the editor window if new lines are added.
     let ignoreEvent = false;
     const updateHeight = () => {
@@ -79,6 +85,56 @@ globalThis.qwebrCreateMonacoEditorInstance = function (cellData) {
         ignoreEvent = false;
       }
     };
+
+    // Function to generate decorations to highlight lines
+    // in the editor based on input string.
+    function decoratorHighlightLines(codeLineNumbers) {
+      // Store the lines to be lighlight
+      let linesToHighlight = [];
+      
+      // Parse the codeLineNumbers string to get the line numbers to highlight
+      // First, split the string by commas
+      codeLineNumbers.split(',').forEach(part => {
+        // Check if we have a range of lines
+        if (part.includes('-')) {
+            // Handle range of lines (e.g., "6-8")
+            const [start, end] = part.split('-').map(Number);
+            for (let i = start; i <= end; i++) {
+                linesToHighlight.push(i);
+            }
+        } else {
+            // Handle single line (e.g., "7")
+            linesToHighlight.push(Number(part));
+        }
+      });
+  
+      // Create monaco decorations for the lines to highlight
+      const decorations = linesToHighlight.map(lineNumber => ({
+          range: new monaco.Range(lineNumber, 1, lineNumber, 1),
+          options: {
+              isWholeLine: true,
+              className: 'qwebr-editor-highlight-line'
+          }
+      }));
+  
+      // Return decorations to be applied to the editor
+      return decorations;
+    }
+
+    // Ensure that the editor-code-line-numbers option is set and valid
+    // then apply styling
+    if (qwebrOptions['editor-code-line-numbers']) {
+      // Remove all whitespace from the string
+      const codeLineNumbers = qwebrOptions['editor-code-line-numbers'].replace(/\s/g,'');
+      // Check if the string is valid for line numbers, e.g., "1,3-5,7"
+      if (isValidCodeLineNumbers(codeLineNumbers)) {
+        // Apply the decorations to the editor
+        editor.createDecorationsCollection(decoratorHighlightLines(codeLineNumbers));
+      } else {
+        // Warn the user that the input is invalid
+        console.warn(`Invalid "editor-code-line-numbers" value in code cell ${qwebrOptions['label']}: ${codeLineNumbers}`);
+      }
+    }
 
     // Helper function to check if selected text is empty
     function isEmptyCodeText(selectedCodeText) {

--- a/docs/demos/qwebr-editor-options.qmd
+++ b/docs/demos/qwebr-editor-options.qmd
@@ -12,16 +12,299 @@ filters:
 ---
 
 :::{.callout-important}
-These features are currently experimental and are included in the 0.4.2-dev.2 build of `{quarto-webr}`.
+These features are currently experimental and are included in the 0.4.2-dev build of `{quarto-webr}`.
 :::
 
 # Overview
 
-This feature demo introduces new options for styling the interactive editor associated with `{webr-r}` code blocks. These editor-specific options offer greater flexibility when working with the Monaco Editor integrated into the interactive area.
+This feature demo introduces [new cell-level options](demos/qwebr-cell-options.qmd#monaco-editor-options) for styling the interactive editor associated with `{webr-r}` code blocks. These editor-specific options offer greater flexibility when working with the Monaco Editor integrated into the interactive area. Options involving the editor are usually prefixed with `editor`. 
 
 :::{.callout-note}
 These options are only configurable during the document authoring stage.
 :::
+
+## `editor-code-line-numbers` Option
+
+Lines inside of the editor may be highlighted through the `editor-code-line-numbers` option. Specifying the highlighting of a line is done by providing a range of line numbers separated by a hyphen or a comma. For example:
+
+- `editor-code-line-numbers: 1-3` will highlight lines 1 to 3.
+- `editor-code-line-numbers: 1,3,5` will highlight lines 1, 3, and 5.
+- `editor-code-line-numbers: 1-3,5` will highlight lines 1 to 3 and 5.
+
+This feature is useful for drawing attention to specific line. You may wish to combine it with `readonly: true`.
+
+### Specifying Ranges
+
+The following cell demonstrates the use of the `editor-code-line-numbers` option to highlight a range of lines in the editor. Lines 1-3 should be highlighted in the editor below.
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+
+```{webr-r}
+#| label: editor-line-numbers
+#| editor-code-line-numbers: 1-3
+hello_world <- function(age) {
+   if (age > 30) {
+       print('You are old')
+	} else { 
+       print('You are young!')
+   }
+}
+hello_age(22)
+```
+
+### Cell Code
+
+```{{webr-r}}
+#| label: editor-line-numbers
+#| editor-code-line-numbers: 1-3
+
+hello_world <- function(age) {
+   if (age > 30) {
+       print('You are old')
+	} else { 
+       print('You are young!')
+   }
+}
+hello_age(22)
+```
+
+:::
+
+### Specifying Single Line
+
+The following cell demonstrates the use of the `editor-code-line-numbers` option to highlight a single line in the editor. Line 2 should be highlighted in the editor below.
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+
+```{webr-r}
+#| label: editor-line-number
+#| editor-code-line-numbers: 2
+
+hello_world <- function(age) {
+   if (age > 30) {
+       print('You are old')
+  } else { 
+       print('You are young!')
+   }
+}
+hello_age(22)
+```
+
+### Cell Code
+```{{webr-r}}
+#| label: editor-line-number
+#| editor-code-line-numbers: 2
+
+hello_world <- function(age) {
+   if (age > 30) {
+       print('You are old')
+  } else { 
+       print('You are young!')
+   }
+}
+hello_age(22)
+```
+
+:::
+
+### Specifying Multiple Lines
+
+The following cell demonstrates the use of the `editor-code-line-numbers` option to highlight multiple lines in the editor. Lines 1 - 3 and 5 should be highlighted in the editor below.
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+
+```{webr-r}
+#| label: editor-multiple-line-numbers
+#| editor-code-line-numbers: 1-3,5
+
+hello_world <- function(age) {
+   if (age > 30) {
+       print('You are old')
+  } else { 
+       print('You are young!')
+   }
+}
+hello_age(22)
+```
+
+### Cell Code
+
+```{{webr-r}}
+#| label: editor-multiple-line-numbers
+#| editor-code-line-numbers: 1-3,5
+
+hello_world <- function(age) {
+   if (age > 30) {
+       print('You are old')
+  } else { 
+       print('You are young!')
+   }
+}
+hello_age(22)
+```
+:::
+
+
+
+## `editor-word-wrap` Option
+
+The editor area allows for text to wrap to the next line when it reaches the end of the editor window.
+This feature is enabled by setting the `editor-word-wrap` option to `true`.
+
+### Wrapped Long Code Lines
+
+In the following cell, the editor window is set to wrap long lines of code to the next line.
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+```{webr-r}
+#| label: editor-word-wrap-enabled
+#| editor-word-wrap: true
+
+# A long line of code that will wrap to the next line in the editor window to avoid horizontal scrolling
+```
+
+### Cell Code
+
+```{{webr-r}}
+#| label: editor-word-wrap-enabled
+#| editor-word-wrap: true
+
+# A long line of code that will wrap to the next line in the editor window to avoid horizontal scrolling
+```
+
+:::
+
+### Unwrapped Long Code Lines
+
+In the following cell, the editor window is set to not wrap long lines of code to the next line.
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+```{webr-r}
+#| label: editor-word-wrap-disabled
+#| editor-word-wrap: false
+
+# A long line of code that will **NOT** wrap to the next line in the editor window and will require horizontal scrolling
+```
+
+### Cell Code
+
+```{{webr-r}}
+#| label: editor-word-wrap-disabled
+#| editor-word-wrap: false
+
+# A long line of code that will **NOT** wrap to the next line in the editor window and will require horizontal scrolling
+```
+
+:::
+
+
+
+## `editor-quick-suggestions` Option
+
+Suggestions based on autocompletion can be enabled by setting the `editor-quick-suggestions` option to `true`. Enabling autocompletion means that the name of variables and functions will be viewable in a pop-up menu after pausing for a while on a line of code.
+
+### Enabled Suggestions
+
+In the following cell, you should be able to access on a new line of code the variable "supercalifragilisticexpialidocious" by pausing after typing `super`.
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+```{webr-r}
+#| label: editor-suggestions-enabled
+#| editor-quick-suggestions: true
+
+supercalifragilisticexpialidocious = 42L
+
+# Try typing super ... 
+su
+
+```
+### Cell Code
+
+```{{webr-r}}
+#| label: editor-suggestions-enabled
+#| editor-quick-suggestions: true
+
+supercalifragilisticexpialidocious = 42L
+
+# Try typing super ...
+su
+
+```
+
+:::
+
+:::{.callout-note}
+We've temporarily disabled editor quick suggestions by default as the options presented were often more confusing than intended.
+:::
+
+## `editor-max-height` Option
+
+The editor maximum line height is now controlable through the `editor-max-height` option. By default, the editor is set to grow infinitely as new lines of code are added. By specifying a pixel value, all lines up to the threshold will be shown while later lines will require the use of the scroll bar in the editor window to access.
+
+### Fixed Height
+
+The following editor has a fixed height of 50 pixels. 
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+```{webr-r}
+#| label: editor-fixed-growth
+#| editor-max-height: 50
+1 + 1
+
+print("hello")
+```
+
+### Cell Code
+```{{webr-r}}
+#| label: editor-fixed-growth
+#| editor-max-height: 50
+1 + 1
+
+print("hello")
+```
+
+:::
+
+### Infinite Height
+
+The following editor has a fixed height of 200. 
+
+:::{.panel-tabset}
+
+### quarto-webr Output
+
+```{webr-r}
+#| label: editor-infinite-growth
+1 + 1
+
+print("hello")
+```
+
+### Cell Code
+
+```{{webr-r}}
+#| label: editor-infinite-growth
+1 + 1
+
+print("hello")
+```
+
+:::
+
 
 ## `editor-font-scale` Option
 
@@ -38,7 +321,6 @@ By default, we set `editor-font-scale` to 1, aligning the editor font size with 
 Let's consider a standard code cell that fits a linear model and obtains the confidence intervals for one or more parameters in a fitted model:
 
 ```{r}
-#| echo: true
 fit = lm(mpg ~ am, data = mtcars)
 
 confint(fit)
@@ -134,6 +416,7 @@ confint(fit)
 ````
 :::
 
+
 # Fin
 
-Just the beginning!
+We're excited to see how you use these new editor specific options to enhance your interactive documents. If you have any feedback or suggestions, please let us know by [opening an issue](https://github.com/coatless/quarto-webr/issues/new/choose) on the `{quarto-webr}` GitHub repository.

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -25,21 +25,18 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 - Added ability to download the R history of commands executed through a new global menu in the right column and underneath Revealjs' "Tools" menu. ([#148](https://github.com/coatless/quarto-webr/issues/148))
 
-- Added a mouse over button to allow for downloading an image when generated. ([#147](https://github.com/coatless/quarto-webr/issues/147))
-
-- Added `cell-options` document-level option to specify global defaults for `{webr-r}` options ([#173](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
-
-- Added `version` document-level option to specify what version of webR should be used. Default embedded version. ([#211](https://github.com/coatless/quarto-webr/issues/211))
-
-- Added `editor-max-height` cell option to limit growth of the editor window. ([#177](https://github.com/coatless/quarto-webr/issues/177), thanks [ute](https://github.com/ute)!)
-
-- Added `editor-font-scale` cell option to scale the code cell size relative to the page font size. Default is `1` for HTML Documents, Books, and Websites and `0.5` for Revealjs Slides. ([#172](https://github.com/coatless/quarto-webr/issues/172) & [#209](https://github.com/coatless/quarto-webr/pull/209), thanks [ute](https://github.com/ute)!)
-
-- Added `editor-quick-suggestions` cell option to enable autocomplete menu suggestions. Default `"false"`.([#182](https://github.com/coatless/quarto-webr/issues/182), thanks [egenn](https://github.com/egenn)!)
-
-- Added `editor-word-wrap` cell option to allow long lines to be wrapped inside of the code cell. Default `"true"`. ([#38](https://github.com/coatless/quarto-webr/issues/38))
-
 - Added the ability to have the monaco editor switch between Quarto's light and dark theme modes. ([#176](https://github.com/coatless/quarto-webr/issues/176))
+
+- Added multiple new document-level options:
+  - `cell-options` specifies global defaults for `{webr-r}` options ([#173](https://github.com/coatless/quarto-webr/pulls/173), thanks [ute](https://github.com/ute)!)
+  - `version` specifies what version of webR should be used. Default embedded version. ([#211](https://github.com/coatless/quarto-webr/issues/211))
+
+- Added the `editor-` class of cell-level options:
+  -  `editor-code-line-numbers` allows highlighting code lines in the editor window. ([#204](https://github.com/coatless/quarto-webr/issues/204))
+  - `editor-max-height` limits growth of the editor window. ([#177](https://github.com/coatless/quarto-webr/issues/177), thanks [ute](https://github.com/ute)!)
+  - `editor-font-scale` scales the code cell size relative to the page font size. Default is `1` for HTML Documents, Books, and Websites and `0.5` for Revealjs Slides. ([#172](https://github.com/coatless/quarto-webr/issues/172) & [#209](https://github.com/coatless/quarto-webr/pull/209), thanks [ute](https://github.com/ute)!)
+  -  `editor-quick-suggestions` enables autocomplete menu suggestions. Default `"false"`.([#182](https://github.com/coatless/quarto-webr/issues/182), thanks [egenn](https://github.com/egenn)!)
+  -  `editor-word-wrap` allows long lines to be wrapped inside of the code cell. Default `"true"`. ([#38](https://github.com/coatless/quarto-webr/issues/38))
 
 - Enabled non-graphical computation within a `webr-r` cell when `OffScreenCanvas` is not available. ([#155](https://github.com/coatless/quarto-webr/issues/155), thanks for raising it [@mccarthy-m-g](https://github.com/mccarthy-m-g))
   - If `OffScreenCanvas` is not available, we now display a Quarto warning callout at the start of the document that emphasizes only non-graphical computation is available and a gentle nudge to upgrade the web browser being used.
@@ -47,6 +44,8 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 
 ## Changes
+
+- Added a mouse over button to allow for downloading an image when generated. ([#147](https://github.com/coatless/quarto-webr/issues/147))
 
 - Increase the minimum Quarto version requirement to 1.4.554.  ([#198](https://github.com/coatless/quarto-webr/issues/198)).
 - Upgraded to webR v0.3.2 ([#187](https://github.com/coatless/quarto-webr/issues/187))

--- a/tests/qwebr-test-editor-options.qmd
+++ b/tests/qwebr-test-editor-options.qmd
@@ -47,3 +47,56 @@ my_long_variable = 1
 
 prin
 ```
+
+
+## Highlight
+
+Opt-in to auto suggestions.
+
+### Only 1 line 
+```{webr-r}
+#| editor-code-line-numbers:1
+my_long_variable = 1
+
+1 + 1
+
+print("hello!")
+```
+
+### Line 1 and 5 
+```{webr-r}
+#| editor-code-line-numbers:1,5
+my_long_variable = 1
+
+1 + 1
+
+print("hello!")
+```
+
+### Line 1-3 and 5 
+
+```{webr-r}
+#| editor-code-line-numbers:1-3,5
+my_long_variable = 1
+
+1 + 1
+
+print("hello!")
+```
+
+
+## Word wrap
+
+### Enabled Wrap
+```{webr-r}
+#| editor-word-wrap: true
+
+my_extra_extra_extra_extra_extra_long_variable = 1
+```
+
+### Disabled Wrap
+```{webr-r}
+#| editor-word-wrap: false
+
+my_extra_extra_extra_extra_extra_long_variable = 1
+```


### PR DESCRIPTION
This PR implements line highlighting under `editor-code-line-numbers` using syntax similar to RevealJS's `code-line-numbers` inside Quarto. 

- `editor-code-line-numbers: 1-3` will highlight lines 1 to 3.
- `editor-code-line-numbers: 1,3,5` will highlight lines 1, 3, and 5.
- `editor-code-line-numbers: 1-3,5` will highlight lines 1 to 3 and 5.

Close #204