### PR TITLE
Remove space after options

### DIFF
--- a/_extensions/webr/_extension.yml
+++ b/_extensions/webr/_extension.yml
@@ -1,7 +1,7 @@
 name: webr
 title: Embedded webr code cells
 author: James Joseph Balamuta
-version: 0.4.2-dev.7
+version: 0.4.2-dev.8
 quarto-required: ">=1.4.554"
 contributes:
   filters:

--- a/_extensions/webr/webr.lua
+++ b/_extensions/webr/webr.lua
@@ -585,21 +585,9 @@ end
 ---@return table
 local function removeEmptyLinesUntilContent(codeLines)
 
-  -- Iterate through each line in the codeText table
-  for _, line in ipairs(codeLines) do
-
-      -- Detect leading whitespace (newline, return character, or empty space)
-      local detectedWhitespace = string.match(line, "^%s*$")
-
-      -- Check if the detectedWhitespace is either an empty string or nil
-      -- This indicates whitespace was detected
-      if isVariableEmpty(detectedWhitespace) then
-          -- Delete empty space
-          table.remove(codeLines, 1)
-      else
-          -- Stop the loop as we now have content
-          break
-      end
+  -- Remove empty lines at the beginning of the code block
+  while codeLines[1] and string.match(codeLines[1], "^%s*$") do
+    table.remove(codeLines, 1)
   end
 
   -- Return the modified table
@@ -639,8 +627,11 @@ local function extractCodeBlockOptions(block)
   -- Merge cell options with default options
   cellOptions = mergeCellOptions(cellOptions)
 
+  -- Remove empty lines at the beginning of the code block
+  local restructuredCodeCell = removeEmptyLinesUntilContent(newCodeLines)
+
   -- Return the code alongside options
-  return newCodeLines, cellOptions
+  return restructuredCodeCell, cellOptions
 end
 
 --- Replace the code cell with a webR-powered cell
@@ -705,11 +696,8 @@ local function enableWebRCodeCell(el)
     end
   end
 
-  -- Remove space left between options and code contents
-  local restructuredCodeCell = removeEmptyLinesUntilContent(cellCode)
-
-  -- Set the codeblock text to exclude the special comments.
-  local cellCodeMerged = table.concat(restructuredCodeCell, '\n')
+    -- Set the codeblock text to exclude the special comments.
+  local cellCodeMerged = table.concat(cellCode, '\n')
 
   -- Create a new table for the CodeBlock
   local codeBlockData = {

--- a/docs/qwebr-code-cell-demos.qmd
+++ b/docs/qwebr-code-cell-demos.qmd
@@ -102,16 +102,19 @@ Lines of code can be highlighted using `editor-code-line-numbers` to draw attent
 
 - `editor-code-line-numbers: 1-3` will highlight lines 1 to 3.
 - `editor-code-line-numbers: 1,3,6` will highlight lines 1, 3, and 6.
-- `editor-code-line-numbers: 1-3,6` will highlight lines 1 to 3 and 6.
+- `editor-code-line-numbers: 1,3-5,7` will highlight lines 1, 3 to 5, and 7.
+
+We can see the `1,3-5,7` example in the following code cell:
 
 ::: {.panel-tabset}
 ## `{quarto-webr}` Output
 
 ```{webr-r}
 #| read-only: true
-#| editor-code-line-numbers: 1-3,6
+#| editor-code-line-numbers: 1,3-5,7
 
 # This is a comment
+
 1 + 1
 2 + 2
 3 + 3
@@ -123,9 +126,10 @@ Lines of code can be highlighted using `editor-code-line-numbers` to draw attent
 
 ```{{webr-r}}
 #| read-only: true
-#| editor-code-line-numbers: 1-3,6
+#| editor-code-line-numbers: 1,3-5,7
 
 # This is a comment
+
 1 + 1
 2 + 2
 3 + 3

--- a/docs/qwebr-release-notes.qmd
+++ b/docs/qwebr-release-notes.qmd
@@ -57,6 +57,7 @@ Features listed under the `-dev` version have not yet been solidified and may ch
 
 ## Bug fixes
 
+- Newline characters that separate options from code lines are now removed. ([#217](https://github.com/coatless/quarto-webr/pulls/217))
 - Prevented vertical scroll bars from always being present by modifying the adaptive container of the editor to always be at least 2 pixels greater than the editor's content instead of being the exact amount. ([#164](https://github.com/coatless/quarto-webr/issues/164))
 
 ## Documentation

--- a/tests/qwebr-test-option-space-removal.qmd
+++ b/tests/qwebr-test-option-space-removal.qmd
@@ -1,0 +1,43 @@
+---
+title: "Test: Space Removal after Options"
+format: html
+engine: knitr
+filters:
+  - webr
+---
+
+Check that the editor contents avoids retaining spaces after the options.
+
+## Space 
+
+```{webr-r}
+#| autorun: true
+
+print("test")
+1 + 1
+```
+
+
+## Multiple Spaces
+
+```{webr-r}
+#| autorun: true
+
+
+
+
+print("test")
+
+1 + 1
+
+```
+
+
+## No Space 
+
+```{webr-r}
+#| autorun: true
+print("test")
+
+1 + 1
+```

--- a/tests/qwebr-test-option-space-removal.qmd
+++ b/tests/qwebr-test-option-space-removal.qmd
@@ -8,7 +8,8 @@ filters:
 
 Check that the editor contents avoids retaining spaces after the options.
 
-## Space 
+
+## Option with a Single Space 
 
 ```{webr-r}
 #| autorun: true
@@ -17,6 +18,20 @@ print("test")
 1 + 1
 ```
 
+## Multiple Options with a Single Space 
+
+```{webr-r}
+#| read-only: true
+#| editor-code-line-numbers: 1,3-5,7
+
+# This is a comment
+
+1 + 1
+2 + 2
+3 + 3
+
+# This is another comment
+```
 
 ## Multiple Spaces
 
@@ -40,4 +55,13 @@ print("test")
 print("test")
 
 1 + 1
+```
+
+
+## No Options
+
+```{webr-r}
+fit <- lm(mpg ~ vs, data = mtcars)
+
+summary(fit)
 ```


### PR DESCRIPTION
Removes the whitespace character immediately following `#|` options

